### PR TITLE
Install centos-release-gluster38 explicitly

### DIFF
--- a/CentOS/Dockerfile
+++ b/CentOS/Dockerfile
@@ -15,9 +15,11 @@ rm -f /lib/systemd/system/sockets.target.wants/*initctl*; \
 rm -f /lib/systemd/system/basic.target.wants/*;\
 rm -f /lib/systemd/system/anaconda.target.wants/*;
 
-RUN yum --setopt=tsflags=nodocs -y install wget nfs-utils attr iputils iproute centos-release-gluster
+RUN yum --setopt=tsflags=nodocs -y install wget nfs-utils attr iputils iproute centos-release-gluster38
 
-RUN yum --setopt=tsflags=nodocs -y install openssh-server openssh-clients ntp rsync tar cronie sudo xfsprogs glusterfs glusterfs-server glusterfs-geo-replication;yum clean all;
+RUN yum --setopt=tsflags=nodocs -y install openssh-server openssh-clients ntp rsync tar cronie sudo xfsprogs glusterfs glusterfs-server glusterfs-geo-replication
+
+RUN yum clean all
 
 RUN sed -i '/Defaults    requiretty/c\#Defaults    requiretty' /etc/sudoers
 

--- a/CentOS/Dockerfile
+++ b/CentOS/Dockerfile
@@ -1,6 +1,6 @@
 FROM centos:latest
 
-MAINTAINER Humble Chirammal hchiramm@redhat.com
+MAINTAINER Humble Chirammal <hchiramm@redhat.com> Mohamed Ashiq Liyaudeen <mliyazud@redhat.com>
 
 ENV container docker
 


### PR DESCRIPTION
In case of gluster 3.9 release, This Dockerfile will not pull the latest. It will pull gluster-3.8