### PR TITLE
Adding gluster-object to gluster docker hub

### DIFF
--- a/gluster-object/CentOS/docker-gluster-swift/Dockerfile
+++ b/gluster-object/CentOS/docker-gluster-swift/Dockerfile
@@ -1,0 +1,65 @@
+FROM centos:7
+MAINTAINER Prashanth Pai <ppai@redhat.com>
+
+# centos-release-openstack-kilo package resides in the extras repo.
+# All subsequent actual packages come from the CentOS Cloud SIG repo:
+# http://mirror.centos.org/centos/7/cloud/x86_64/
+
+# Install PACO servers and S3 middleware.
+# Install gluster-swift dependencies. To be removed when RPMs become available.
+# Clean downloaded packages and index
+
+RUN yum -v --setopt=tsflags=nodocs -y update && \
+    yum -v --setopt=tsflags=nodocs -y install \
+        centos-release-openstack-kilo \
+        epel-release && \
+    yum -v --setopt=tsflags=nodocs -y install \
+        openstack-swift openstack-swift-{proxy,account,container,object,plugin-swift3} \
+        git memcached python-prettytable && \
+    yum -y install systemd && \
+        (cd /lib/systemd/system/sysinit.target.wants/; for i in *; do [ $i == systemd-tmpfiles-setup.service ] || rm -f $i; done); \
+        rm -f /lib/systemd/system/multi-user.target.wants/*;\
+        rm -f /etc/systemd/system/*.wants/*;\
+        rm -f /lib/systemd/system/local-fs.target.wants/*; \
+        rm -f /lib/systemd/system/sockets.target.wants/*udev*; \
+        rm -f /lib/systemd/system/sockets.target.wants/*initctl*; \
+        rm -f /lib/systemd/system/basic.target.wants/*;\
+        rm -f /lib/systemd/system/anaconda.target.wants/* && \
+    yum -y clean all
+
+# Install gluster-swift from source.
+# TODO: When gluster-swift is shipped as RPM, just use that.
+RUN git clone git://review.gluster.org/gluster-swift /tmp/gluster-swift && \
+    cd /tmp/gluster-swift && \
+    python setup.py install && \
+    cd -
+
+# Gluster volumes will be mounted *under* this directory.
+VOLUME /mnt/gluster-object
+
+# volumes to be exposed as object storage is present in swift-volumes file
+COPY etc/sysconfig/swift-volumes /etc/sysconfig/
+
+# Copy systemd scripts
+COPY swift-gen-builders.service /lib/systemd/system/
+COPY swift-proxy.service /lib/systemd/system/
+COPY swift-account.service /lib/systemd/system/
+COPY swift-container.service /lib/systemd/system/
+COPY swift-object.service /lib/systemd/system/
+
+# Replace openstack swift conf files with local gluster-swift ones
+COPY etc/swift/* /etc/swift/
+
+# The proxy server listens on port 8080
+EXPOSE 8080
+
+RUN echo 'root:password' | chpasswd
+VOLUME [ "/sys/fs/cgroup" ]
+
+RUN systemctl enable swift-gen-builders.service
+RUN systemctl enable memcached.service
+RUN systemctl enable swift-proxy.service
+RUN systemctl enable swift-account.service
+RUN systemctl enable swift-container.service
+RUN systemctl enable swift-object.service
+CMD ["/usr/sbin/init"]

--- a/gluster-object/CentOS/docker-gluster-swift/README.md
+++ b/gluster-object/CentOS/docker-gluster-swift/README.md
@@ -1,0 +1,109 @@
+
+# docker-gluster-swift
+docker-gluster-swift is to provide object interface for a Gluster volume.
+
+Let us see how to run gluster-swift inside a docker container.
+
+## Building
+
+```bash
+# docker build --rm --tag gluster-swift .
+```
+
+## Running
+
+On the host machine, mount one or more gluster volumes under the directory
+`/mnt/gluster-object` with mountpoint name being same as that of the volume.
+
+For example, if you have two gluster volumes named `test` and `test2`, they
+should be mounted at `/mnt/gluster-object/test` and `/mnt/gluster-object/test2`
+respectively. This directory on the host machine containing all the individual
+glusterfs mounts is then bind-mounted inside the container. This avoids having
+to bind mount individual gluster volumes.
+
+The same needs to be updated in etc/sysconfig/swift-volumes.
+For example(in swift-volumes):
+GLUSTER_VOLUMES='tv1'
+
+Where tv1 is the volume name.
+
+**Example:**
+
+```bash
+# docker run -d --privileged  -v /sys/fs/cgroup/:/sys/fs/cgroup/:ro -p 8080:8080 -v /mnt/gluster-object:/mnt/gluster-object    gluster-swift
+```
+
+If you have selinux set to enforced on the host machine, refer to the
+Troubleshooting section below before running the container.
+
+**Note:**
+
+~~~
+-d : Runs the container in the background.
+-p : Publishes the container's port to the host port. They need not be the same.
+     If host port is omitted, a random port will be mapped. So you can run
+     multiple instances of the container, each serving on a different port on
+     the same host machine.
+-v : Bind mount a host path inside the container.
+-e : Set and pass environment variable. In our case, provide a list of volumes
+     to be exported over object inerface by setting GLUSTER_VOLUMES environment
+     variable.
+~~~
+
+### Custom deployment
+
+You can provide your own configuration files and ring files and have the
+swift processes running inside container use those. This can be done by
+placing your conf files and ring files in a directory on your host machine
+and then bind-mounting it inside the container at `/etc/swift`.
+
+**Example:**
+
+Assuming you have conf files and ring files present at `/tmp/swift` on the
+machine, you can spawn the container as follows:
+
+```bash
+# docker run -d -p 8080:8080 -v /tmp/swift:/etc/swift -v /mnt/gluster-object:/mnt/gluster-object prashanthpai/gluster-swift:dev
+```
+
+If the host machine has SELinux set to enforced:
+
+```bash
+# chcon -Rt svirt_sandbox_file_t /tmp/swift
+```
+
+### Troubleshooting
+
+**SELinux**
+
+When a volume is bind mounted inside the container, you'll need blessings of
+SELinux on the host machine. Otherwise, the application inside the container
+won't be able to access the volume. Example:
+
+```bash
+[root@f24 ~]# docker exec -i -t nostalgic_goodall /bin/bash
+[root@042abf4acc4d /]# ls /mnt/gluster-object/
+ls: cannot open directory /mnt/gluster-object/: Permission denied
+```
+
+Ideally, running this command on host machine should work:
+
+```bash
+# chcon -Rt svirt_sandbox_file_t /mnt/gluster-object
+```
+
+However, glusterfs does not support setting of SELinux contexts [yet][1].
+You can always set SELinux to permissive on host machine by running
+`setenforce 0` or run container in privileged mode (`--privileged=true`).
+I don't like either. A better workaround would be to mount the glusterfs
+volumes on host machine as shown in following example:
+
+[1]: https://bugzilla.redhat.com/show_bug.cgi?id=1252627
+
+```bash
+mount -t glusterfs -o selinux,context="system_u:object_r:svirt_sandbox_file_t:s0" `hostname`:test /mnt/gluster-object/test
+```
+
+### TODO
+
+* Install gluster-swift from RPMs. (Currently installed from source)

--- a/gluster-object/CentOS/docker-gluster-swift/etc/swift/account-server.conf
+++ b/gluster-object/CentOS/docker-gluster-swift/etc/swift/account-server.conf
@@ -1,0 +1,39 @@
+[DEFAULT]
+#
+# Default gluster mount point to be used for object store,can be changed by
+# setting the following value in {account,container,object}-server.conf files.
+# It is recommended to keep this value same for all the three services but can
+# be kept different if environment demands.
+devices = /mnt/gluster-object
+#
+# Once you are confident that your startup processes will always have your
+# gluster volumes properly mounted *before* the account-server workers start,
+# you can *consider* setting this value to "false" to reduce the per-request
+# overhead it can incur.
+mount_check = false
+bind_port = 6012
+#
+# Override swift's default behaviour for fallocate.
+disable_fallocate = true
+#
+# One or two workers should be sufficient for almost any installation of
+# Gluster.
+workers = 1
+
+[pipeline:main]
+pipeline = account-server
+
+[app:account-server]
+use = egg:gluster_swift#account
+user = root
+log_facility = LOG_LOCAL2
+log_level = WARN
+# The following parameter is used by object-expirer and needs to be same
+# across all conf files!
+auto_create_account_prefix = gs
+#
+# After ensuring things are running in a stable manner, you can turn off
+# normal request logging for the account server to unclutter the log
+# files. Warnings and errors will still be logged.
+log_requests = off
+

--- a/gluster-object/CentOS/docker-gluster-swift/etc/swift/container-server.conf
+++ b/gluster-object/CentOS/docker-gluster-swift/etc/swift/container-server.conf
@@ -1,0 +1,39 @@
+[DEFAULT]
+#
+# Default gluster mount point to be used for object store,can be changed by
+# setting the following value in {account,container,object}-server.conf files.
+# It is recommended to keep this value same for all the three services but can
+# be kept different if environment demands.
+devices = /mnt/gluster-object
+#
+# Once you are confident that your startup processes will always have your
+# gluster volumes properly mounted *before* the container-server workers
+# start, you can *consider* setting this value to "false" to reduce the
+# per-request overhead it can incur.
+mount_check = false
+bind_port = 6011
+#
+# Override swift's default behaviour for fallocate.
+disable_fallocate = true
+#
+# One or two workers should be sufficient for almost any installation of
+# Gluster.
+workers = 1
+
+[pipeline:main]
+pipeline = container-server
+
+[app:container-server]
+use = egg:gluster_swift#container
+user = root
+log_facility = LOG_LOCAL2
+log_level = WARN
+# The following parameters is used by object-expirer and needs to be same
+# across all conf files!
+auto_create_account_prefix = gs
+#
+# After ensuring things are running in a stable manner, you can turn off
+# normal request logging for the container server to unclutter the log
+# files. Warnings and errors will still be logged.
+log_requests = off
+

--- a/gluster-object/CentOS/docker-gluster-swift/etc/swift/fs.conf
+++ b/gluster-object/CentOS/docker-gluster-swift/etc/swift/fs.conf
@@ -1,0 +1,24 @@
+[DEFAULT]
+#
+# IP address of a node in the GlusterFS server cluster hosting the
+# volumes to be served via Swift API.
+mount_ip = localhost
+
+# Performance optimization parameter. When turned off, the filesystem will
+# see a reduced number of stat calls, resulting in substantially faster
+# response time for GET and HEAD container requests on containers with large
+# numbers of objects, at the expense of an accurate count of combined bytes
+# used by all objects in the container. For most installations "off" works
+# fine.
+accurate_size_in_listing = off
+
+# In older versions of gluster-swift, metadata stored as xattrs of dirs/files
+# were serialized using PICKLE format. The PICKLE format is vulnerable to
+# exploits in deployments where a user has access to backend filesystem over
+# FUSE/SMB. Deserializing pickled metadata can result in malicious code being
+# executed if an attacker has stored malicious code as xattr from filesystem
+# interface. Although, new metadata is always serialized using JSON format,
+# existing metadata already stored in PICKLE format are loaded by default.
+# You can turn this option to 'off' once you have migrated all your metadata
+# from PICKLE format to JSON format using gluster-swift-migrate-metadata tool.
+read_pickled_metadata = on

--- a/gluster-object/CentOS/docker-gluster-swift/etc/swift/object-expirer.conf
+++ b/gluster-object/CentOS/docker-gluster-swift/etc/swift/object-expirer.conf
@@ -1,0 +1,61 @@
+[DEFAULT]
+user = root
+# Default gluster mount point to be used for object store,can be changed by
+# setting the following value in {account,container,object}-server.conf files.
+devices = /mnt/gluster-object
+
+[object-expirer]
+user = root
+log_facility = LOG_LOCAL2
+log_level = INFO
+
+# The following parameters are used by object-expirer and needs to be same
+# across all conf files!
+auto_create_account_prefix = gs
+expiring_objects_account_name = expiring
+
+# The expirer will re-attempt expiring if the source object is not available
+# up to reclaim_age seconds before it gives up and deletes the entry in the
+# queue. In gluster-swift, you'd almost always want to set this to zero.
+reclaim_age = 0
+
+# Do not retry DELETEs on getting 404. Hence default is set to 1.
+request_tries = 1
+
+# The swift-object-expirer daemon will run every 'interval' number of seconds
+# interval = 300
+
+# Emit a log line report of the progress so far every 'report_interval'
+# number of seconds.
+# report_interval = 300
+
+# concurrency is the level of concurrency to use to do the work, this value
+# must be set to at least 1
+# concurrency = 1
+
+# processes is how many parts to divide the work into, one part per process
+# that will be doing the work
+# processes set 0 means that a single process will be doing all the work
+# processes can also be specified on the command line and will override the
+# config value
+# processes = 0
+
+# process is which of the parts a particular process will work on
+# process can also be specified on the command line and will overide the config
+# value
+# process is "zero based", if you want to use 3 processes, you should run
+# processes with process set to 0, 1, and 2
+# process = 0
+
+
+[pipeline:main]
+pipeline = catch_errors cache proxy-server
+
+[app:proxy-server]
+use = egg:gluster_swift#proxy
+
+[filter:cache]
+use = egg:swift#memcache
+
+[filter:catch_errors]
+use = egg:swift#catch_errors

--- a/gluster-object/CentOS/docker-gluster-swift/etc/swift/object-server.conf
+++ b/gluster-object/CentOS/docker-gluster-swift/etc/swift/object-server.conf
@@ -1,0 +1,55 @@
+[DEFAULT]
+#
+# Default gluster mount point to be used for object store,can be changed by
+# setting the following value in {account,container,object}-server.conf files.
+# It is recommended to keep this value same for all the three services but can
+# be kept different if environment demands.
+devices = /mnt/gluster-object
+#
+# Once you are confident that your startup processes will always have your
+# gluster volumes properly mounted *before* the object-server workers start,
+# you can *consider* setting this value to "false" to reduce the per-request
+# overhead it can incur.
+mount_check = false
+bind_port = 6010
+#
+# Maximum number of clients one worker can process simultaneously (it will
+# actually accept N + 1). Setting this to one (1) will only handle one request
+# at a time, without accepting another request concurrently. By increasing the
+# number of workers to a much higher value, one can prevent slow file system
+# operations for one request from starving other requests.
+max_clients = 1024
+#
+# If not doing the above, setting this value initially to match the number of
+# CPUs is a good starting point for determining the right value.
+workers = 1
+# Override swift's default behaviour for fallocate.
+disable_fallocate = true
+
+[pipeline:main]
+pipeline = object-server
+
+[app:object-server]
+use = egg:gluster_swift#object
+user = root
+log_facility = LOG_LOCAL2
+log_level = WARN
+# The following parameters are used by object-expirer and needs to be same
+# across all conf files!
+auto_create_account_prefix = gs
+expiring_objects_account_name = expiring
+#
+# For performance, after ensuring things are running in a stable manner, you
+# can turn off normal request logging for the object server to reduce the
+# per-request overhead and unclutter the log files. Warnings and errors will
+# still be logged.
+log_requests = off
+#
+# Adjust this value to match the stripe width of the underlying storage array
+# (not the stripe element size). This will provide a reasonable starting point
+# for tuning this value.
+disk_chunk_size = 65536
+#
+# Adjust this value match whatever is set for the disk_chunk_size initially.
+# This will provide a reasonable starting point for tuning this value.
+network_chunk_size = 65536

--- a/gluster-object/CentOS/docker-gluster-swift/etc/swift/proxy-server.conf
+++ b/gluster-object/CentOS/docker-gluster-swift/etc/swift/proxy-server.conf
@@ -1,0 +1,99 @@
+[DEFAULT]
+bind_port = 8080
+user = root
+# Consider using 1 worker per CPU
+workers = 1
+
+[pipeline:main]
+pipeline = catch_errors gatekeeper healthcheck proxy-logging cache bulk ratelimit swift3 staticweb slo dlo proxy-logging proxy-server
+
+[app:proxy-server]
+use = egg:gluster_swift#proxy
+log_facility = LOG_LOCAL1
+log_level = WARN
+# The API allows for account creation and deletion, but since Gluster/Swift
+# automounts a Gluster volume for a given account, there is no way to create
+# or delete an account. So leave this off.
+allow_account_management = false
+account_autocreate = true
+# The following parameters are used by object-expirer and needs to be same
+# across all conf files!
+auto_create_account_prefix = gs
+expiring_objects_account_name = expiring
+# Ensure the proxy server uses fast-POSTs since we don't need to make a copy
+# of the entire object given that all metadata is stored in the object
+# extended attributes (no .meta file used after creation) and no container
+# sync feature to present.
+object_post_as_copy = false
+# Only need to recheck the account exists once a day
+recheck_account_existence = 86400
+# May want to consider bumping this up if containers are created and destroyed
+# infrequently.
+recheck_container_existence = 60
+# Timeout clients that don't read or write to the proxy server after 5
+# seconds.
+client_timeout = 5
+# Give more time to connect to the object, container or account servers in
+# cases of high load.
+conn_timeout = 5
+# For high load situations, once connected to an object, container or account
+# server, allow for delays communicating with them.
+node_timeout = 60
+# May want to consider bumping up this value to 1 - 4 MB depending on how much
+# traffic is for multi-megabyte or gigabyte requests; perhaps matching the
+# stripe width (not stripe element size) of your storage volume is a good
+# starting point. See below for sizing information.
+object_chunk_size = 65536
+# If you do decide to increase the object_chunk_size, then consider lowering
+# this value to one. Up to "put_queue_length" object_chunk_size'd buffers can
+# be queued to the object server for processing. Given one proxy server worker
+# can handle up to 1,024 connections, by default, it will consume 10 * 65,536
+# * 1,024 bytes of memory in the worse case (default values). Be sure the
+# amount of memory available on the system can accommodate increased values
+# for object_chunk_size.
+put_queue_depth = 10
+
+[filter:catch_errors]
+use = egg:swift#catch_errors
+
+[filter:proxy-logging]
+use = egg:swift#proxy_logging
+access_log_level = WARN
+
+[filter:healthcheck]
+use = egg:swift#healthcheck
+
+[filter:cache]
+use = egg:swift#memcache
+# Update this line to contain a comma separated list of memcache servers
+# shared by all nodes running the proxy-server service.
+memcache_servers = localhost:11211
+
+[filter:gatekeeper]
+use = egg:swift#gatekeeper
+
+[filter:ratelimit]
+use = egg:swift#ratelimit
+
+[filter:bulk]
+use = egg:swift#bulk
+
+[filter:staticweb]
+use = egg:swift#staticweb
+
+[filter:slo]
+use = egg:swift#slo
+
+[filter:dlo]
+use = egg:swift#dlo
+
+[filter:tempauth]
+use = egg:swift#tempauth
+user_admin_admin = admin .admin .reseller_admin
+user_test_tester = testing .admin
+user_test2_tester2 = testing2 .admin
+user_test_tester3 = testing3
+user_test5_tester5 = testing5 service
+
+[filter:swift3]
+use = egg:swift3#swift3

--- a/gluster-object/CentOS/docker-gluster-swift/etc/swift/swift.conf
+++ b/gluster-object/CentOS/docker-gluster-swift/etc/swift/swift.conf
@@ -1,0 +1,85 @@
+[DEFAULT]
+
+
+[swift-hash]
+# random unique string that can never change (DO NOT LOSE)
+swift_hash_path_suffix = gluster
+
+
+# The swift-constraints section sets the basic constraints on data
+# saved in the swift cluster.
+
+[swift-constraints]
+
+# max_file_size is the largest "normal" object that can be saved in
+# the cluster. This is also the limit on the size of each segment of
+# a "large" object when using the large object manifest support.
+# This value is set in bytes. Setting it to lower than 1MiB will cause
+# some tests to fail.
+# Default is 1 TiB = 2**30*1024
+max_file_size = 1099511627776
+
+
+# max_meta_name_length is the max number of bytes in the utf8 encoding
+# of the name portion of a metadata header.
+
+#max_meta_name_length = 128
+
+
+# max_meta_value_length is the max number of bytes in the utf8 encoding
+# of a metadata value
+
+#max_meta_value_length = 256
+
+
+# max_meta_count is the max number of metadata keys that can be stored
+# on a single account, container, or object
+
+#max_meta_count = 90
+
+
+# max_meta_overall_size is the max number of bytes in the utf8 encoding
+# of the metadata (keys + values)
+
+#max_meta_overall_size = 4096
+
+
+# max_object_name_length is the max number of bytes in the utf8 encoding of an
+# object name: Gluster FS can handle much longer file names, but the length
+# between the slashes of the URL is handled below. Remember that most web
+# clients can't handle anything greater than 2048, and those that do are
+# rather clumsy.
+
+max_object_name_length = 2048
+
+# max_object_name_component_length (GlusterFS) is the max number of bytes in
+# the utf8 encoding of an object name component (the part between the
+# slashes); this is a limit imposed by the underlying file system (for XFS it
+# is 255 bytes).
+
+max_object_name_component_length = 255
+
+# container_listing_limit is the default (and max) number of items
+# returned for a container listing request
+
+#container_listing_limit = 10000
+
+
+# account_listing_limit is the default (and max) number of items returned
+# for an account listing request
+
+#account_listing_limit = 10000
+
+
+# max_account_name_length is the max number of bytes in the utf8 encoding of
+# an account name: Gluster FS Filename limit (XFS limit?), must be the same
+# size as max_object_name_component_length above.
+
+max_account_name_length = 255
+
+
+# max_container_name_length is the max number of bytes in the utf8 encoding
+# of a container name: Gluster FS Filename limit (XFS limit?), must be the same
+# size as max_object_name_component_length above.
+
+max_container_name_length = 255

--- a/gluster-object/CentOS/docker-gluster-swift/etc/sysconfig/swift-volumes
+++ b/gluster-object/CentOS/docker-gluster-swift/etc/sysconfig/swift-volumes
@@ -1,0 +1,2 @@
+# Set Gluster volumes to be used by gluster-swift service
+GLUSTER_VOLUMES='tv1'

--- a/gluster-object/CentOS/docker-gluster-swift/memcached.service
+++ b/gluster-object/CentOS/docker-gluster-swift/memcached.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=Memcached Service
+
+[Service]
+ExecStart=/usr/bin/memcached -u root
+Restart=on-abort
+
+[Install]
+WantedBy=multi-user.target

--- a/gluster-object/CentOS/docker-gluster-swift/swift-account.service
+++ b/gluster-object/CentOS/docker-gluster-swift/swift-account.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Swift Account Service
+After=swift-proxy.service
+
+[Service]
+ExecStart=/usr/bin/python /usr/bin/swift-account-server /etc/swift/account-server.conf
+Restart=on-abort
+
+[Install]
+WantedBy=multi-user.target

--- a/gluster-object/CentOS/docker-gluster-swift/swift-container.service
+++ b/gluster-object/CentOS/docker-gluster-swift/swift-container.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Swift Container Service
+After=swift-account.service
+
+[Service]
+ExecStart=/usr/bin/python /usr/bin/swift-container-server /etc/swift/container-server.conf
+Restart=on-abort
+
+[Install]
+WantedBy=multi-user.target

--- a/gluster-object/CentOS/docker-gluster-swift/swift-gen-builders.service
+++ b/gluster-object/CentOS/docker-gluster-swift/swift-gen-builders.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Swift Gen Builders
+Before=memcached.service
+
+[Service]
+Type=oneshot
+EnvironmentFile=-/etc/sysconfig/swift-volumes
+ExecStart=/usr/bin/gluster-swift-gen-builders $GLUSTER_VOLUMES
+
+[Install]
+WantedBy=multi-user.target

--- a/gluster-object/CentOS/docker-gluster-swift/swift-object.service
+++ b/gluster-object/CentOS/docker-gluster-swift/swift-object.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Swift Object Service
+After=swift-container.service
+
+[Service]
+ExecStart=/usr/bin/python /usr/bin/swift-object-server /etc/swift/object-server.conf
+Restart=on-abort
+
+[Install]
+WantedBy=multi-user.target

--- a/gluster-object/CentOS/docker-gluster-swift/swift-proxy.service
+++ b/gluster-object/CentOS/docker-gluster-swift/swift-proxy.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Swift Proxy Service
+After=memcached.service
+
+[Service]
+ExecStart=/usr/bin/python /usr/bin/swift-proxy-server /etc/swift/proxy-server.conf
+Restart=on-abort
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Adding gluster-object to gluster docker hub.
Current change are for CentOS.

Refer docker-gluster-swift/README.md for setting up gluster-object Docker container.

Signed-off-by: Saravanakumar Arumugam <sarumuga@redhat.com>