### PR TITLE
CentOS/Dockerfile: fixed use of unicode quotation marks

### DIFF
--- a/CentOS/Dockerfile
+++ b/CentOS/Dockerfile
@@ -44,7 +44,7 @@ ADD gluster-setup.sh /usr/sbin/gluster-setup.sh
 RUN chmod 500 /usr/sbin/gluster-setup.sh
 
 RUN echo 'root:password' | chpasswd
-VOLUME [ “/sys/fs/cgroup” ]
+VOLUME [ "/sys/fs/cgroup" ]
 
 RUN systemctl disable nfs-server.service
 RUN systemctl enable ntpd.service


### PR DESCRIPTION
I've just run into issues trying to use the [`gluster/gluster-centos`](https://hub.docker.com/r/gluster/gluster-centos/) with `docker-compose`. It seems to have issues parsing `gluster-centos`'s Dockerfile:

```
docker-compose up -d
gluster_peervpn_1 is up-to-date
Recreating gluster_glusterfs-server_1

ERROR: for glusterfs-server  'ascii' codec can't decode byte 0xe2 in position 90: ordinal not in range(128)
Traceback (most recent call last):
  File "bin/docker-compose", line 3, in <module>
  File "compose/cli/main.py", line 88, in main
  File "compose/cli/main.py", line 140, in perform_command
  File "compose/cli/main.py", line 900, in up
  File "compose/project.py", line 416, in up
  File "compose/parallel.py", line 66, in parallel_execute
UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 90: ordinal not in range(128)
Failed to execute script docker-compose
Makefile:31: recipe for target '_setup-gluster1' failed
make: *** [_setup-gluster1] Error 255
```

The issue was that `CentOS/Dockerfile` uses unicode quotation marks (`“` and `”`) instead of standard ASCII ones (`"`) in line 47.

Hexdump (with the two culprits being `e2 80 9c` and `e2 80 9d`)

```
000007e0  72 64 27 20 7c 20 63 68  70 61 73 73 77 64 0a 56  |rd' | chpasswd.V|
000007f0  4f 4c 55 4d 45 20 5b 20  e2 80 9c 2f 73 79 73 2f  |OLUME [ .../sys/|
00000800  66 73 2f 63 67 72 6f 75  70 e2 80 9d 20 5d 0a 0a  |fs/cgroup... ]..|
00000810  52 55 4e 20 73 79 73 74  65 6d 63 74 6c 20 64 69  |RUN systemctl di|
```

I guess `docker` itself silently converts unicode quotation marks, but `docker-compose` (and I guess most other third party tools) doesn't.