### PR TITLE
Pass gluster volume as argument while running docker

### DIFF
--- a/gluster-object/CentOS/docker-gluster-swift/Dockerfile
+++ b/gluster-object/CentOS/docker-gluster-swift/Dockerfile
@@ -37,9 +37,6 @@ RUN git clone git://review.gluster.org/gluster-swift /tmp/gluster-swift && \
 # Gluster volumes will be mounted *under* this directory.
 VOLUME /mnt/gluster-object
 
-# volumes to be exposed as object storage is present in swift-volumes file
-COPY etc/sysconfig/swift-volumes /etc/sysconfig/
-
 # Copy systemd scripts
 COPY swift-gen-builders.service /lib/systemd/system/
 COPY swift-proxy.service /lib/systemd/system/
@@ -49,6 +46,13 @@ COPY swift-object.service /lib/systemd/system/
 
 # Replace openstack swift conf files with local gluster-swift ones
 COPY etc/swift/* /etc/swift/
+
+# To update volume name used by swift-gen-builders service
+COPY update_gluster_vol.sh /usr/local/bin/update_gluster_vol.sh
+RUN chmod +x /usr/local/bin/update_gluster_vol.sh
+
+# volumes to be exposed as object storage is present in swift-volumes file
+COPY etc/sysconfig/swift-volumes /etc/sysconfig/swift-volumes
 
 # The proxy server listens on port 8080
 EXPOSE 8080
@@ -62,4 +66,6 @@ RUN systemctl enable swift-proxy.service
 RUN systemctl enable swift-account.service
 RUN systemctl enable swift-container.service
 RUN systemctl enable swift-object.service
+
+ENTRYPOINT ["/usr/local/bin/update_gluster_vol.sh"]
 CMD ["/usr/sbin/init"]

--- a/gluster-object/CentOS/docker-gluster-swift/README.md
+++ b/gluster-object/CentOS/docker-gluster-swift/README.md
@@ -30,7 +30,7 @@ Where tv1 is the volume name.
 **Example:**
 
 ```bash
-# docker run -d --privileged  -v /sys/fs/cgroup/:/sys/fs/cgroup/:ro -p 8080:8080 -v /mnt/gluster-object:/mnt/gluster-object    gluster-swift
+# docker run -d --privileged  -v /sys/fs/cgroup/:/sys/fs/cgroup/:ro -p 8080:8080 -v /mnt/gluster-object:/mnt/gluster-object    -e GLUSTER_VOLUMES="tv1" gluster-swift
 ```
 
 If you have selinux set to enforced on the host machine, refer to the

--- a/gluster-object/CentOS/docker-gluster-swift/etc/sysconfig/swift-volumes
+++ b/gluster-object/CentOS/docker-gluster-swift/etc/sysconfig/swift-volumes
@@ -1,2 +1,2 @@
-# Set Gluster volumes to be used by gluster-swift service
-GLUSTER_VOLUMES='tv1'
+# Set Gluster volumes to be used by gluster-object service
+GLUSTER_VOLUMES="tv1"

--- a/gluster-object/CentOS/docker-gluster-swift/update_gluster_vol.sh
+++ b/gluster-object/CentOS/docker-gluster-swift/update_gluster_vol.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# To update gluster volume name in swift-volumes, used by swift-gen-builders.service
+if [ -z "$GLUSTER_VOLUMES" ]; then
+        echo "You need to set GLUSTER_VOLUMES env variable"
+        exit 1
+else
+        echo "GLUSTER_VOLUMES env variable is set. Update in swift-volumes"
+        sed -i.bak '/^GLUSTER_VOLUMES=/s/=.*/='\""$GLUSTER_VOLUMES"\"'/' /etc/sysconfig/swift-volumes
+fi
+
+# Hand off to CMD
+exec "$@"


### PR DESCRIPTION
This will be updated by update_gluster_vol.sh in swift-volumes file.

This will be inturn be used by swift-gen-builders service.

Updated README to pass gluster volume.

Signed-off-by: Saravanakumar Arumugam <sarumuga@redhat.com>