### PR TITLE
Volume mount in dockerfile uses “ instead of "

### DIFF
--- a/CentOS-7/Dockerfile
+++ b/CentOS-7/Dockerfile
@@ -46,7 +46,7 @@ ADD gluster-setup.sh /usr/sbin/gluster-setup.sh
 RUN chmod 500 /usr/sbin/gluster-setup.sh
 
 #RUN echo 'root:password' | chpasswd
-VOLUME [ “/sys/fs/cgroup” ]
+VOLUME [ "/sys/fs/cgroup" ]
 
 RUN systemctl disable nfs-server.service
 RUN systemctl enable ntpd.service

--- a/Fedora-22/Dockerfile
+++ b/Fedora-22/Dockerfile
@@ -39,7 +39,7 @@ ADD gluster-setup.sh /usr/sbin/gluster-setup.sh
 RUN chmod 500 /usr/sbin/gluster-setup.sh
 
 #RUN echo 'root:password' | chpasswd
-VOLUME [ “/sys/fs/cgroup” ]
+VOLUME [ "/sys/fs/cgroup" ]
 
 RUN systemctl disable nfs-server.service
 RUN systemctl enable ntpd.service

--- a/Fedora-23/Dockerfile
+++ b/Fedora-23/Dockerfile
@@ -37,7 +37,7 @@ ADD gluster-setup.sh /usr/sbin/gluster-setup.sh
 RUN chmod 500 /usr/sbin/gluster-setup.sh
 
 #RUN echo 'root:password' | chpasswd
-VOLUME [ “/sys/fs/cgroup” ]
+VOLUME [ "/sys/fs/cgroup" ]
 
 RUN systemctl disable nfs-server.service
 RUN systemctl enable ntpd.service


### PR DESCRIPTION
Signed-off-by: Mohamed Ashiq Liyazudeen <mliyazud@redhat.com>