### PR TITLE
Remove unused memcached.service file.

### DIFF
--- a/gluster-s3object/CentOS/docker-gluster-s3/memcached.service
+++ b/gluster-s3object/CentOS/docker-gluster-s3/memcached.service
@@ -1,9 +1,0 @@
-[Unit]
-Description=Memcached Service
-
-[Service]
-ExecStart=/usr/bin/memcached -u root
-Restart=on-abort
-
-[Install]
-WantedBy=multi-user.target


### PR DESCRIPTION
Remove unused memcached.service file.
This file will be installed during yum install itself.

Signed-off-by: Saravanakumar Arumugam <sarumuga@redhat.com>