### PR TITLE
Fedora: don't use the :latest tag for the base container

### DIFF
--- a/Fedora/Dockerfile
+++ b/Fedora/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.fedoraproject.org/fedora:latest
+FROM registry.fedoraproject.org/fedora
 
 ENV NAME="gluster-fedora" \
     DESC="GlusterFS on Fedora" \


### PR DESCRIPTION
When building the Fedora docker container with the process ends with an error
message like

  Step 1/9 : FROM registry.fedoraproject.org/fedora:latest
  manifest for registry.fedoraproject.org/fedora:latest not found

It seems that the :latest tag is not available in the Fedora registry.

Signed-off-by: Niels de Vos <ndevos@redhat.com>