### PR TITLE
fix mangling of host sysctl

### DIFF
--- a/CentOS/Dockerfile
+++ b/CentOS/Dockerfile
@@ -43,6 +43,7 @@ RUN chmod 644 /etc/systemd/system/gluster-setup.service; \
 chmod 500 /usr/sbin/gluster-setup.sh; \
 systemctl disable nfs-server.service; \
 systemctl mask getty.target; \
+systemctl mask systemd-sysctl.service; \
 systemctl enable ntpd.service; \
 systemctl enable glusterd.service; \
 systemctl enable gluster-setup.service;

--- a/Fedora/Dockerfile
+++ b/Fedora/Dockerfile
@@ -52,6 +52,7 @@ RUN dnf -y update && \
     chmod 644 /etc/systemd/system/gluster-brickmultiplex.service && \
     chmod 500 /usr/sbin/gluster-brickmultiplex.sh && \
     systemctl mask getty.target && \
+    systemctl mask systemd-sysctl.service && \
     systemctl disable systemd-udev-trigger.service && \
     systemctl disable systemd-udevd.service && \
     systemctl disable nfs-server.service && \


### PR DESCRIPTION
This commit fixes the glusterfs container changing host's sysctl when
starting up as a privileged container.
(net.bridge.bridge-nf-call-iptables and net.bridge.bridge-nf-call-ip6tables
in particular)