### PR TITLE
fix bug when multiple shell commands are specified in RUN

### DIFF
--- a/CentOS/Dockerfile
+++ b/CentOS/Dockerfile
@@ -14,38 +14,38 @@ LABEL architecture="x86_64" \
       description="Gluster Image is based on CentOS Image which is a scalable network filesystem. Using common off-the-shelf hardware, you can create large, distributed storage solutions for media streaming, data analysis, and other data- and bandwidth-intensive tasks." \
       io.openshift.tags="gluster,glusterfs,glusterfs-centos"
 
-RUN yum --setopt=tsflags=nodocs -y update; yum install -y centos-release-gluster313; yum clean all; \
-(cd /lib/systemd/system/sysinit.target.wants/; for i in *; do [ $i == systemd-tmpfiles-setup.service ] || rm -f $i; done); \
-rm -f /lib/systemd/system/multi-user.target.wants/*;\
-rm -f /etc/systemd/system/*.wants/*;\
-rm -f /lib/systemd/system/local-fs.target.wants/*; \
-rm -f /lib/systemd/system/sockets.target.wants/*udev*; \
-rm -f /lib/systemd/system/sockets.target.wants/*initctl*; \
-rm -f /lib/systemd/system/basic.target.wants/*;\
-rm -f /lib/systemd/system/anaconda.target.wants/*;\
-yum --setopt=tsflags=nodocs -y install nfs-utils attr iputils iproute openssh-server openssh-clients ntp rsync tar cronie sudo xfsprogs glusterfs glusterfs-server glusterfs-rdma glusterfs-geo-replication;yum clean all; \
-sed -i '/Defaults    requiretty/c\#Defaults    requiretty' /etc/sudoers; \
-sed -i '/Port 22/c\Port 2222' /etc/ssh/sshd_config; \
-sed -i 's/Requires\=rpcbind\.service//g' /usr/lib/systemd/system/glusterd.service; \
-sed -i 's/rpcbind\.service/gluster-setup\.service/g' /usr/lib/systemd/system/glusterd.service; \
-sed -i 's/ENV{DM_UDEV_DISABLE_OTHER_RULES_FLAG}=="1", ENV{SYSTEMD_READY}="0"/ENV{DM_UDEV_DISABLE_OTHER_RULES_FLAG}=="1", GOTO="systemd_end"/g' /usr/lib/udev/rules.d/99-systemd.rules; \
-mkdir -p /etc/glusterfs_bkp /var/lib/glusterd_bkp /var/log/glusterfs_bkp;\
-cp -r /etc/glusterfs/* /etc/glusterfs_bkp;\
-cp -r /var/lib/glusterd/* /var/lib/glusterd_bkp;\
-cp -r /var/log/glusterfs/* /var/log/glusterfs_bkp; \
-sed -i.save -e "s#udev_sync = 1#udev_sync = 0#" -e "s#udev_rules = 1#udev_rules = 0#" -e "s#use_lvmetad = 1#use_lvmetad = 0#" /etc/lvm/lvm.conf;
+RUN yum --setopt=tsflags=nodocs -y update && yum install -y centos-release-gluster313 && yum clean all && \
+(cd /lib/systemd/system/sysinit.target.wants/ && for i in * && do [ $i == systemd-tmpfiles-setup.service ] || rm -f $i && done) && \
+rm -f /lib/systemd/system/multi-user.target.wants/* &&\
+rm -f /etc/systemd/system/*.wants/* &&\
+rm -f /lib/systemd/system/local-fs.target.wants/* && \
+rm -f /lib/systemd/system/sockets.target.wants/*udev* && \
+rm -f /lib/systemd/system/sockets.target.wants/*initctl* && \
+rm -f /lib/systemd/system/basic.target.wants/* &&\
+rm -f /lib/systemd/system/anaconda.target.wants/* &&\
+yum --setopt=tsflags=nodocs -y install nfs-utils attr iputils iproute openssh-server openssh-clients ntp rsync tar cronie sudo xfsprogs glusterfs glusterfs-server glusterfs-rdma glusterfs-geo-replication &&yum clean all && \
+sed -i '/Defaults    requiretty/c\#Defaults    requiretty' /etc/sudoers && \
+sed -i '/Port 22/c\Port 2222' /etc/ssh/sshd_config && \
+sed -i 's/Requires\=rpcbind\.service//g' /usr/lib/systemd/system/glusterd.service && \
+sed -i 's/rpcbind\.service/gluster-setup\.service/g' /usr/lib/systemd/system/glusterd.service && \
+sed -i 's/ENV{DM_UDEV_DISABLE_OTHER_RULES_FLAG}=="1", ENV{SYSTEMD_READY}="0"/ENV{DM_UDEV_DISABLE_OTHER_RULES_FLAG}=="1", GOTO="systemd_end"/g' /usr/lib/udev/rules.d/99-systemd.rules && \
+mkdir -p /etc/glusterfs_bkp /var/lib/glusterd_bkp /var/log/glusterfs_bkp &&\
+cp -r /etc/glusterfs/* /etc/glusterfs_bkp &&\
+cp -r /var/lib/glusterd/* /var/lib/glusterd_bkp &&\
+cp -r /var/log/glusterfs/* /var/log/glusterfs_bkp && \
+sed -i.save -e "s#udev_sync = 1#udev_sync = 0#" -e "s#udev_rules = 1#udev_rules = 0#" -e "s#use_lvmetad = 1#use_lvmetad = 0#" /etc/lvm/lvm.conf &&
 
 VOLUME [ "/sys/fs/cgroup" ]
 ADD gluster-setup.service /etc/systemd/system/gluster-setup.service
 ADD gluster-setup.sh /usr/sbin/gluster-setup.sh
 
-RUN chmod 644 /etc/systemd/system/gluster-setup.service; \
-chmod 500 /usr/sbin/gluster-setup.sh; \
-systemctl disable nfs-server.service; \
-systemctl mask getty.target; \
-systemctl enable ntpd.service; \
-systemctl enable glusterd.service; \
-systemctl enable gluster-setup.service;
+RUN chmod 644 /etc/systemd/system/gluster-setup.service && \
+chmod 500 /usr/sbin/gluster-setup.sh && \
+systemctl disable nfs-server.service && \
+systemctl mask getty.target && \
+systemctl enable ntpd.service && \
+systemctl enable glusterd.service && \
+systemctl enable gluster-setup.service &&
 
 EXPOSE 2222 111 245 443 24007 2049 8080 6010 6011 6012 38465 38466 38468 38469 49152 49153 49154 49156 49157 49158 49159 49160 49161 49162
 

--- a/gluster-client/Dockerfile
+++ b/gluster-client/Dockerfile
@@ -14,9 +14,10 @@ LABEL architecture="x86_64" \
 
 ENV container docker
 
-RUN dnf --setopt=tsflags=nodocs -y update; dnf --setopt=tsflags=nodocs -y install wget nfs-utils attr iputils iproute; \
-sed -i "s/LANG/\#LANG/g" /etc/locale.conf;\
-dnf install -y glusterfs-fuse;\
-dnf clean all;
+RUN sed -i "s/LANG/\#LANG/g" /etc/locale.conf
+RUN dnf --setopt=tsflags=nodocs -y update &&\
+dnf --setopt=tsflags=nodocs -y install wget nfs-utils attr iputils iproute &&\
+dnf install -y glusterfs-fuse &&\
+dnf clean all
 
 CMD ["/bin/bash"]

--- a/gluster-s3object/CentOS/docker-gluster-s3/Dockerfile
+++ b/gluster-s3object/CentOS/docker-gluster-s3/Dockerfile
@@ -27,13 +27,13 @@ RUN yum -v --setopt=tsflags=nodocs -y update && \
         openstack-swift openstack-swift-{proxy,account,container,object,plugin-swift3} \
         git memcached python-prettytable python-setuptools && \
     yum -y install systemd && \
-        (cd /lib/systemd/system/sysinit.target.wants/; for i in *; do [ $i == systemd-tmpfiles-setup.service ] || rm -f $i; done); \
-        rm -f /lib/systemd/system/multi-user.target.wants/*;\
-        rm -f /etc/systemd/system/*.wants/*;\
-        rm -f /lib/systemd/system/local-fs.target.wants/*; \
-        rm -f /lib/systemd/system/sockets.target.wants/*udev*; \
-        rm -f /lib/systemd/system/sockets.target.wants/*initctl*; \
-        rm -f /lib/systemd/system/basic.target.wants/*;\
+        (cd /lib/systemd/system/sysinit.target.wants/; for i in *; do [ $i == systemd-tmpfiles-setup.service ] || rm -f $i; done) && \
+        rm -f /lib/systemd/system/multi-user.target.wants/* &&\
+        rm -f /etc/systemd/system/*.wants/* &&\
+        rm -f /lib/systemd/system/local-fs.target.wants/* && \
+        rm -f /lib/systemd/system/sockets.target.wants/*udev* && \
+        rm -f /lib/systemd/system/sockets.target.wants/*initctl* && \
+        rm -f /lib/systemd/system/basic.target.wants/* &&\
         rm -f /lib/systemd/system/anaconda.target.wants/* && \
     yum -y clean all
 
@@ -75,13 +75,13 @@ EXPOSE 8080
 RUN echo 'root:password' | chpasswd
 VOLUME [ "/sys/fs/cgroup" ]
 
-RUN systemctl enable swift-gen-builders.service;\
-systemctl enable memcached.service;\
-systemctl enable swift-proxy.service;\
-systemctl enable swift-account.service;\
-systemctl enable swift-container.service;\
-systemctl enable swift-object.service;\
-systemctl enable swift-adduser.service;
+RUN systemctl enable swift-gen-builders.service &&\
+systemctl enable memcached.service &&\
+systemctl enable swift-proxy.service &&\
+systemctl enable swift-account.service &&\
+systemctl enable swift-container.service &&\
+systemctl enable swift-object.service &&\
+systemctl enable swift-adduser.service
 
 ENTRYPOINT ["/usr/local/bin/update_gluster_vol.sh"]
 CMD ["/usr/sbin/init"]


### PR DESCRIPTION
If RUN is followed by two commands only the return value of second
determines whether RUN was successful or not. This may lead to cases
where docker build succeeds even when it should not.

For example
RUN /bin/false; /bin/true

would be considered a success.

Important thing to consider is that all yum/dnf commands should perform
clean in the same RUN operation if we wish to keep the container image
size small. Running clean in a second RUN operation leads to bigger
image size contrary to expectation because each operation leads to a
layer in the image.

With the above two points considered, I have replaced ";" with "&&"
where necessary and split a single RUN operation to two or many
operations in other places.

Signed-off-by: Raghavendra Talur <rtalur@redhat.com>