### PR TITLE
retain semi-colon in a subshell related to for loop

### DIFF
--- a/CentOS/Dockerfile
+++ b/CentOS/Dockerfile
@@ -15,7 +15,7 @@ LABEL architecture="x86_64" \
       io.openshift.tags="gluster,glusterfs,glusterfs-centos"
 
 RUN yum --setopt=tsflags=nodocs -y update && yum install -y centos-release-gluster313 && yum clean all && \
-(cd /lib/systemd/system/sysinit.target.wants/ && for i in * && do [ $i == systemd-tmpfiles-setup.service ] || rm -f $i && done) && \
+(cd /lib/systemd/system/sysinit.target.wants/; for i in *; do [ $i == systemd-tmpfiles-setup.service ] || rm -f $i; done) && \
 rm -f /lib/systemd/system/multi-user.target.wants/* &&\
 rm -f /etc/systemd/system/*.wants/* &&\
 rm -f /lib/systemd/system/local-fs.target.wants/* && \
@@ -23,7 +23,7 @@ rm -f /lib/systemd/system/sockets.target.wants/*udev* && \
 rm -f /lib/systemd/system/sockets.target.wants/*initctl* && \
 rm -f /lib/systemd/system/basic.target.wants/* &&\
 rm -f /lib/systemd/system/anaconda.target.wants/* &&\
-yum --setopt=tsflags=nodocs -y install nfs-utils attr iputils iproute openssh-server openssh-clients ntp rsync tar cronie sudo xfsprogs glusterfs glusterfs-server glusterfs-rdma glusterfs-geo-replication &&yum clean all && \
+yum --setopt=tsflags=nodocs -y install nfs-utils attr iputils iproute openssh-server openssh-clients ntp rsync tar cronie sudo xfsprogs glusterfs glusterfs-server glusterfs-rdma glusterfs-geo-replication && yum clean all && \
 sed -i '/Defaults    requiretty/c\#Defaults    requiretty' /etc/sudoers && \
 sed -i '/Port 22/c\Port 2222' /etc/ssh/sshd_config && \
 sed -i 's/Requires\=rpcbind\.service//g' /usr/lib/systemd/system/glusterd.service && \
@@ -33,7 +33,7 @@ mkdir -p /etc/glusterfs_bkp /var/lib/glusterd_bkp /var/log/glusterfs_bkp &&\
 cp -r /etc/glusterfs/* /etc/glusterfs_bkp &&\
 cp -r /var/lib/glusterd/* /var/lib/glusterd_bkp &&\
 cp -r /var/log/glusterfs/* /var/log/glusterfs_bkp && \
-sed -i.save -e "s#udev_sync = 1#udev_sync = 0#" -e "s#udev_rules = 1#udev_rules = 0#" -e "s#use_lvmetad = 1#use_lvmetad = 0#" /etc/lvm/lvm.conf &&
+sed -i.save -e "s#udev_sync = 1#udev_sync = 0#" -e "s#udev_rules = 1#udev_rules = 0#" -e "s#use_lvmetad = 1#use_lvmetad = 0#" /etc/lvm/lvm.conf
 
 VOLUME [ "/sys/fs/cgroup" ]
 ADD gluster-setup.service /etc/systemd/system/gluster-setup.service
@@ -45,7 +45,7 @@ systemctl disable nfs-server.service && \
 systemctl mask getty.target && \
 systemctl enable ntpd.service && \
 systemctl enable glusterd.service && \
-systemctl enable gluster-setup.service &&
+systemctl enable gluster-setup.service
 
 EXPOSE 2222 111 245 443 24007 2049 8080 6010 6011 6012 38465 38466 38468 38469 49152 49153 49154 49156 49157 49158 49159 49160 49161 49162
 


### PR DESCRIPTION
The previous fix replaced semi-colon with && in Dockerfiles. I missed a
for loop and replaced semi-colon inside it too.

Signed-off-by: Raghavendra Talur <rtalur@redhat.com>