### PR TITLE
Add /usr/lib/modules as a new volume to enable loading of kernel modules

### DIFF
--- a/CentOS/Dockerfile
+++ b/CentOS/Dockerfile
@@ -36,6 +36,9 @@ cp -r /var/log/glusterfs/* /var/log/glusterfs_bkp && \
 sed -i.save -e "s#udev_sync = 1#udev_sync = 0#" -e "s#udev_rules = 1#udev_rules = 0#" -e "s#use_lvmetad = 1#use_lvmetad = 0#" /etc/lvm/lvm.conf
 
 VOLUME [ "/sys/fs/cgroup" ]
+# It is recommended to use LVM for bricks, which may require loading kernel modules
+VOLUME [ "/usr/lib/modules" ]
+
 ADD gluster-setup.service /etc/systemd/system/gluster-setup.service
 ADD gluster-setup.sh /usr/sbin/gluster-setup.sh
 

--- a/Fedora/Dockerfile
+++ b/Fedora/Dockerfile
@@ -22,6 +22,8 @@ LABEL name="$REPO/$NAME" \
       maintainer="Jose A. Rivera <jarrpa@redhat.com>, Humble Chirammal <hchiramm@redhat.com>"
 
 VOLUME [ "/sys/fs/cgroup/" ]
+# It is recommended to use LVM for bricks, which may require loading kernel modules
+VOLUME [ "/usr/lib/modules" ]
 
 ADD https://github.com/gluster/gluster-containers/blob/master/README.md /README.md
 


### PR DESCRIPTION
It is recommended to create bricks on top of LVM (with thin-pool
provisioning). This requires certain device-mapper features in the
kernel. If these are missing, the lvm-tools will try to load the
appropriate kernel modules. Loading of kernel modules is only possible
if the .ko files are available inside the container.

Fixes: #75
Related: gluster/gluster-kubernetes#457
Signed-off-by: Niels de Vos <ndevos@redhat.com>