### PR TITLE
Remove NTP service from gluster container

### DIFF
--- a/CentOS/Dockerfile
+++ b/CentOS/Dockerfile
@@ -23,7 +23,7 @@ rm -f /lib/systemd/system/sockets.target.wants/*udev* && \
 rm -f /lib/systemd/system/sockets.target.wants/*initctl* && \
 rm -f /lib/systemd/system/basic.target.wants/* &&\
 rm -f /lib/systemd/system/anaconda.target.wants/* &&\
-yum --setopt=tsflags=nodocs -y install nfs-utils attr iputils iproute openssh-server openssh-clients ntp rsync tar cronie sudo xfsprogs glusterfs glusterfs-server glusterfs-rdma glusterfs-geo-replication && yum clean all && \
+yum --setopt=tsflags=nodocs -y install nfs-utils attr iputils iproute openssh-server openssh-clients rsync tar cronie sudo xfsprogs glusterfs glusterfs-server glusterfs-rdma glusterfs-geo-replication && yum clean all && \
 sed -i '/Defaults    requiretty/c\#Defaults    requiretty' /etc/sudoers && \
 sed -i '/Port 22/c\Port 2222' /etc/ssh/sshd_config && \
 sed -i 's/Requires\=rpcbind\.service//g' /usr/lib/systemd/system/glusterd.service && \
@@ -43,7 +43,6 @@ RUN chmod 644 /etc/systemd/system/gluster-setup.service && \
 chmod 500 /usr/sbin/gluster-setup.sh && \
 systemctl disable nfs-server.service && \
 systemctl mask getty.target && \
-systemctl enable ntpd.service && \
 systemctl enable glusterd.service && \
 systemctl enable gluster-setup.service
 

--- a/Fedora/Dockerfile
+++ b/Fedora/Dockerfile
@@ -29,7 +29,7 @@ COPY gluster-setup.sh gluster-brickmultiplex.service gluster-brickmultiplex.sh g
 
 RUN dnf -y update && \
     sed -i "s/LANG/\#LANG/g" /etc/locale.conf && \
-    dnf -y install systemd-udev ntp glusterfs-server dbus-python nfs-utils attr iputils iproute glusterfs-geo-replication openssh-server openssh-clients cronie tar rsync sos sudo xfsprogs && \
+    dnf -y install systemd-udev glusterfs-server dbus-python nfs-utils attr iputils iproute glusterfs-geo-replication openssh-server openssh-clients cronie tar rsync sos sudo xfsprogs && \
     dnf clean all && \
     sed -i '/Port 22/c\Port 2222' /etc/ssh/sshd_config && \
     sed -i 's/Requires\=rpcbind\.service//g' /usr/lib/systemd/system/glusterd.service && \
@@ -57,7 +57,6 @@ RUN dnf -y update && \
     systemctl disable nfs-server.service && \
     systemctl enable rpcbind.service && \
     systemctl enable sshd.service && \
-    systemctl enable ntpd.service && \
     systemctl enable gluster-setup.service && \
     systemctl enable gluster-brickmultiplex.service && \
     systemctl enable glusterd.service

--- a/README.md
+++ b/README.md
@@ -57,7 +57,12 @@ Before this, ensure the following directories are created on the host where dock
  - /etc/glusterfs
  - /var/lib/glusterd
  - /var/log/glusterfs
-Also, ensure they are empty to avoid any conflicts.
+
+Ensure all the above directories are empty to avoid any conflicts.
+
+Also, ntp service like chronyd / ntpd service needs to be started in the host.
+This way all the gluster containers started will be time synchronized.
+
 Now run the following command:
 
 ~~~


### PR DESCRIPTION
Remove NTP service from gluster container.

Run NTP service like chronyd (or) ntpd in host itself.

Note, the time is shared between host and container
whereas timezone is not.
As long as time in host is synchronized, there is no need to
run NTP service inside container as well.

Signed-off-by: Saravanakumar Arumugam <sarumuga@redhat.com>