### PR TITLE
Upgrade to centos-release-openstack-pike (from newton release).

### DIFF
--- a/CentOS/Dockerfile
+++ b/CentOS/Dockerfile
@@ -23,7 +23,21 @@ rm -f /lib/systemd/system/sockets.target.wants/*udev* && \
 rm -f /lib/systemd/system/sockets.target.wants/*initctl* && \
 rm -f /lib/systemd/system/basic.target.wants/* &&\
 rm -f /lib/systemd/system/anaconda.target.wants/* &&\
-yum --setopt=tsflags=nodocs -y install nfs-utils attr iputils iproute openssh-server openssh-clients rsync tar cronie sudo xfsprogs glusterfs glusterfs-server glusterfs-rdma glusterfs-geo-replication && yum clean all && \
+yum --setopt=tsflags=nodocs -y install nfs-utils && \
+yum --setopt=tsflags=nodocs -y install attr  && \
+yum --setopt=tsflags=nodocs -y install iputils  && \
+yum --setopt=tsflags=nodocs -y install iproute  && \
+yum --setopt=tsflags=nodocs -y install openssh-server  && \
+yum --setopt=tsflags=nodocs -y install openssh-clients  && \
+yum --setopt=tsflags=nodocs -y install rsync  && \
+yum --setopt=tsflags=nodocs -y install tar  && \
+yum --setopt=tsflags=nodocs -y install cronie  && \
+yum --setopt=tsflags=nodocs -y install sudo  && \
+yum --setopt=tsflags=nodocs -y install xfsprogs  && \
+yum --setopt=tsflags=nodocs -y install glusterfs  && \
+yum --setopt=tsflags=nodocs -y install glusterfs-server  && \
+yum --setopt=tsflags=nodocs -y install glusterfs-rdma  && \
+yum --setopt=tsflags=nodocs -y install glusterfs-geo-replication && yum clean all && \
 sed -i '/Defaults    requiretty/c\#Defaults    requiretty' /etc/sudoers && \
 sed -i '/Port 22/c\Port 2222' /etc/ssh/sshd_config && \
 sed -i 's/Requires\=rpcbind\.service//g' /usr/lib/systemd/system/glusterd.service && \

--- a/gluster-s3object/CentOS/docker-gluster-s3/Dockerfile
+++ b/gluster-s3object/CentOS/docker-gluster-s3/Dockerfile
@@ -1,7 +1,7 @@
 FROM centos:7
 MAINTAINER Prashanth Pai <ppai@redhat.com>
 
-# centos-release-openstack-newton package resides in the extras repo.
+# centos-release-openstack-pike package resides in the extras repo.
 # All subsequent actual packages come from the CentOS Cloud SIG repo:
 # http://mirror.centos.org/centos/7/cloud/x86_64/
 
@@ -11,7 +11,7 @@ MAINTAINER Prashanth Pai <ppai@redhat.com>
 
 LABEL architecture="x86_64" \
       name="gluster/gluster-swift" \
-      version="newton" \
+      version="pike" \
       vendor="Red Hat, Inc" \
       summary="This image has a running gluster-swift service ( centos 7 + gluster-swift)" \
       io.k8s.display-name="gluster-swift based on centos 7" \
@@ -20,9 +20,8 @@ LABEL architecture="x86_64" \
       io.openshift.tags="gluster,glusterfs,gluster-swift"
 
 RUN yum -v --setopt=tsflags=nodocs -y update && \
-    yum -v --setopt=tsflags=nodocs -y install \
-        centos-release-openstack-newton \
-        epel-release && \
+    yum -v --setopt=tsflags=nodocs -y install centos-release-openstack-pike && \
+    yum -v --setopt=tsflags=nodocs -y install epel-release && \
     yum -v --setopt=tsflags=nodocs -y install \
         openstack-swift openstack-swift-{proxy,account,container,object,plugin-swift3} \
         git memcached python-prettytable python-setuptools && \


### PR DESCRIPTION
Also, run yum install with single package at a time.
    Note, if yum installs multiple packages in a single line, even if one
    package is available it proceeds without erroring out.

    So, it is better to install single package in docker RUN command.
    It will error out if the corresponding package is unavailable.

    In this case, centos-release-openstack-newton was missing, but
    epel-release was available.

Signed-off-by: Saravanakumar Arumugam <sarumuga@redhat.com>