### PR TITLE
Set coredump file's location as /var/log/glusterfs/core_%e.%p

### DIFF
--- a/CentOS/gluster-setup.sh
+++ b/CentOS/gluster-setup.sh
@@ -91,7 +91,7 @@ main () {
   fi
 
   # Set core file location - format: core_<executable_name>.<pid>
-  echo '/var/log/glusterfs/core_%e.%p' | sudo tee /proc/sys/kernel/core_pattern
+  echo '/var/log/glusterfs/core_%e.%p' | tee /proc/sys/kernel/core_pattern
 
   echo "Script Ran Successfully"
   exit 0

--- a/CentOS/gluster-setup.sh
+++ b/CentOS/gluster-setup.sh
@@ -90,6 +90,9 @@ main () {
         echo "heketi-fstab not found"
   fi
 
+  # Set core file location - format: core_<executable_name>.<pid>
+  echo '/var/log/glusterfs/core_%e.%p' | sudo tee /proc/sys/kernel/core_pattern
+
   echo "Script Ran Successfully"
   exit 0
 }

--- a/Fedora/gluster-setup.sh
+++ b/Fedora/gluster-setup.sh
@@ -91,7 +91,7 @@ main () {
   fi
 
   # Set core file location - format: core_<executable_name>.<pid>
-  echo '/var/log/glusterfs/core_%e.%p' | sudo tee /proc/sys/kernel/core_pattern
+  echo '/var/log/glusterfs/core_%e.%p' | tee /proc/sys/kernel/core_pattern
 
   echo "Script Ran Successfully"
   exit 0

--- a/Fedora/gluster-setup.sh
+++ b/Fedora/gluster-setup.sh
@@ -90,6 +90,9 @@ main () {
         echo "heketi-fstab not found"
   fi
 
+  # Set core file location - format: core_<executable_name>.<pid>
+  echo '/var/log/glusterfs/core_%e.%p' | sudo tee /proc/sys/kernel/core_pattern
+
   echo "Script Ran Successfully"
   exit 0
 }


### PR DESCRIPTION
Set coredump file's location as /var/log/glusterfs/core_%e.%p

Signed-off-by: Saravanakumar Arumugam <sarumuga@redhat.com>