### PR TITLE
Add a directory named /var/log/core in gluster container.

### DIFF
--- a/CentOS/Dockerfile
+++ b/CentOS/Dockerfile
@@ -49,7 +49,8 @@ mkdir -p /etc/glusterfs_bkp /var/lib/glusterd_bkp /var/log/glusterfs_bkp &&\
 cp -r /etc/glusterfs/* /etc/glusterfs_bkp &&\
 cp -r /var/lib/glusterd/* /var/lib/glusterd_bkp &&\
 cp -r /var/log/glusterfs/* /var/log/glusterfs_bkp && \
-sed -i.save -e "s#udev_sync = 1#udev_sync = 0#" -e "s#udev_rules = 1#udev_rules = 0#" -e "s#use_lvmetad = 1#use_lvmetad = 0#" /etc/lvm/lvm.conf
+sed -i.save -e "s#udev_sync = 1#udev_sync = 0#" -e "s#udev_rules = 1#udev_rules = 0#" -e "s#use_lvmetad = 1#use_lvmetad = 0#" /etc/lvm/lvm.conf && \
+mkdir -p /var/log/core;
 
 VOLUME [ "/sys/fs/cgroup" ]
 ADD gluster-setup.service /etc/systemd/system/gluster-setup.service

--- a/Fedora/Dockerfile
+++ b/Fedora/Dockerfile
@@ -59,7 +59,8 @@ RUN dnf -y update && \
     systemctl enable sshd.service && \
     systemctl enable gluster-setup.service && \
     systemctl enable gluster-brickmultiplex.service && \
-    systemctl enable glusterd.service
+    systemctl enable glusterd.service && \
+    mkdir -p /var/log/core;
 
 EXPOSE 2222 111 245 443 24006 24007 2049 8080 6010 6011 6012 38465 38466 38468 38469 49152 49153 49154 49156 49157 49158 49159 49160 49161 49162
 

--- a/README.md
+++ b/README.md
@@ -128,9 +128,24 @@ Number of Peers: 0
 
 -bash-4.3# gluster --version
 ~~~
+
 That’s it!
 
 Additional Ref# https://goo.gl/3031Mm
+
+##### Capturing coredumps
+
+/var/log/core directory is already added in the container.
+Coredumps can be configured to be generated under /var/log/core directory.
+
+User can copy the coredump(s) generated under /var/log/core/ directory
+from the container to the host.
+
+For example:
+~~~
+ssh <hostmachine>
+sysctl -w kernel.core_pattern=/var/log/core/core_%e.%p
+~~~
 
 ## Gluster Object Docker container:
 

--- a/gluster-client/Dockerfile
+++ b/gluster-client/Dockerfile
@@ -20,4 +20,7 @@ dnf --setopt=tsflags=nodocs -y install wget nfs-utils attr iputils iproute &&\
 dnf install -y glusterfs-fuse &&\
 dnf clean all
 
+# Directory for coredumps. Note,kernel.core_pattern must be configured as such
+RUN mkdir -p /var/log/core
+
 CMD ["/bin/bash"]

--- a/gluster-s3object/CentOS/docker-gluster-s3/Dockerfile
+++ b/gluster-s3object/CentOS/docker-gluster-s3/Dockerfile
@@ -82,5 +82,8 @@ systemctl enable swift-container.service &&\
 systemctl enable swift-object.service &&\
 systemctl enable swift-adduser.service
 
+# Directory for coredumps. Note,kernel.core_pattern must be configured as such
+RUN mkdir -p /var/log/core
+
 ENTRYPOINT ["/usr/local/bin/update_gluster_vol.sh"]
 CMD ["/usr/sbin/init"]


### PR DESCRIPTION
If kernel.core_pattern is configured as /var/log/core/, then coredumps
will be generated here.

User can then copy the coredumps generated from container to Host.

Signed-off-by: Saravanakumar Arumugam <sarumuga@redhat.com>