### PR TITLE
Enable gluster-block services if GLUSTER_BLOCK_ENABLED is TRUE and

### DIFF
--- a/CentOS/Dockerfile
+++ b/CentOS/Dockerfile
@@ -94,8 +94,6 @@ systemctl disable nfs-server.service && \
 systemctl mask getty.target && \
 systemctl enable gluster-fake-disk.service && \
 systemctl enable gluster-setup.service && \
-systemctl enable gluster-block-setup.service && \
-systemctl enable gluster-blockd.service && \
 systemctl enable glusterd.service && \
 systemctl enable gluster-check-diskspace.service
 

--- a/CentOS/update-params.sh
+++ b/CentOS/update-params.sh
@@ -4,16 +4,26 @@
 : ${GB_LOGDIR:=/var/log/glusterfs/gluster-block}
 : ${TCMU_LOGDIR:=/var/log/glusterfs/gluster-block}
 : ${GB_GLFS_LRU_COUNT:=15}
+: ${GLUSTER_BLOCK_ENABLED:=TRUE}
 
-echo "env variable is set. Update in gluster-blockd.service"
-#FIXME To update in environment file
-sed -i '/GB_GLFS_LRU_COUNT=/s/GB_GLFS_LRU_COUNT=.*/'GB_GLFS_LRU_COUNT="$GB_GLFS_LRU_COUNT"\"'/'  /usr/lib/systemd/system/gluster-blockd.service
-sed -i '/EnvironmentFile/i Environment="GB_LOGDIR='$GB_LOGDIR'"' /usr/lib/systemd/system/gluster-blockd.service
+if [ "$GLUSTER_BLOCK_ENABLED" == TRUE ]; then
+        echo "Enabling gluster-block service and updating env. variables"
+        systemctl enable gluster-block-setup.service
+        systemctl enable gluster-blockd.service
 
-sed -i "s#TCMU_LOGDIR=.*#TCMU_LOGDIR='$TCMU_LOGDIR'#g" /etc/sysconfig/tcmu-runner-params
+        #FIXME To update in environment file
+        sed -i '/GB_GLFS_LRU_COUNT=/s/GB_GLFS_LRU_COUNT=.*/'GB_GLFS_LRU_COUNT="$GB_GLFS_LRU_COUNT"\"'/'  /usr/lib/systemd/system/gluster-blockd.service
+        sed -i '/EnvironmentFile/i Environment="GB_LOGDIR='$GB_LOGDIR'"' /usr/lib/systemd/system/gluster-blockd.service
 
-sed -i '/ExecStart/i EnvironmentFile=-/etc/sysconfig/tcmu-runner-params' /usr/lib/systemd/system/tcmu-runner.service
-sed -i  '/tcmu-log-dir=/s/tcmu-log-dir.*/tcmu-log-dir $TCMU_LOGDIR/' /usr/lib/systemd/system/tcmu-runner.service
+        sed -i "s#TCMU_LOGDIR=.*#TCMU_LOGDIR='$TCMU_LOGDIR'#g" /etc/sysconfig/tcmu-runner-params
+
+        sed -i '/ExecStart/i EnvironmentFile=-/etc/sysconfig/tcmu-runner-params' /usr/lib/systemd/system/tcmu-runner.service
+        sed -i  '/tcmu-log-dir=/s/tcmu-log-dir.*/tcmu-log-dir $TCMU_LOGDIR/' /usr/lib/systemd/system/tcmu-runner.service
+else
+        echo "Disabling gluster-block service"
+        systemctl disable gluster-block-setup.service
+        systemctl disable gluster-blockd.service
+fi
 
 # Hand off to CMD
 exec "$@"


### PR DESCRIPTION
Use env. variable GLUSTER_BLOCK_ENABLED to enable/disable gluster-block service.

Enable gluster-block services if GLUSTER_BLOCK_ENABLED is TRUE and disable otherwise.

By default, GLUSTER_BLOCK_ENABLED is set as TRUE.

Signed-off-by: Saravanakumar Arumugam <sarumuga@redhat.com>