### PR TITLE
gluster-setup: create a fake disk when USE_FAKE_DISK is set

### DIFF
--- a/CentOS/Dockerfile
+++ b/CentOS/Dockerfile
@@ -69,6 +69,8 @@ RUN true \
     && true
 
 VOLUME [ "/sys/fs/cgroup" ]
+ADD gluster-fake-disk.service /etc/systemd/system/gluster-fake-disk.service
+ADD fake-disk.sh /usr/libexec/gluster/fake-disk.sh
 ADD gluster-setup.service /etc/systemd/system/gluster-setup.service
 ADD gluster-setup.sh /usr/sbin/gluster-setup.sh
 ADD gluster-block-setup.service /etc/systemd/system/gluster-block-setup.service
@@ -81,6 +83,7 @@ ADD check_diskspace.sh /usr/local/bin/check_diskspace.sh
 
 RUN chmod 644 /etc/systemd/system/gluster-setup.service && \
 chmod 644 /etc/systemd/system/gluster-check-diskspace.service && \
+chmod 755 /usr/libexec/gluster/fake-disk.sh && \
 chmod 500 /usr/sbin/gluster-setup.sh && \
 chmod 644 /etc/systemd/system/gluster-block-setup.service && \
 chmod 500 /usr/sbin/gluster-block-setup.sh && \
@@ -89,6 +92,7 @@ chmod +x /usr/local/bin/status-probe.sh && \
 chmod +x /usr/local/bin/check_diskspace.sh && \
 systemctl disable nfs-server.service && \
 systemctl mask getty.target && \
+systemctl enable gluster-fake-disk.service && \
 systemctl enable gluster-setup.service && \
 systemctl enable gluster-block-setup.service && \
 systemctl enable gluster-blockd.service && \

--- a/CentOS/README.md
+++ b/CentOS/README.md
@@ -1,1 +1,26 @@
 This dockerfile can be used to build a CentOS Gluster Container.
+
+# Support for fake disks
+
+This container offers several configuration options that make it easier to test
+the functionality. It is possible to configure a fake disk so that there is no
+requirement for additional block devices on the container host. The container
+has a `gluster-fake-disk` service that consumes the following environment
+variables:
+
+- `USE_FAKE_DISK` (default is empty) when set to a non-empty value, setup a
+  fake disk. The other environment variables have defaults and do not need to
+  be set.
+
+- `FAKE_DISK_FILE` (defaults to `/srv/fake-disk.img`) the fake disk will be
+  backed by this file. To have persistent storage, make sure to have the
+  directory where this file is located bind-mounted as a volume in the
+  container.
+
+- `FAKE_DISK_SIZE` (defaults to `10G`) sets the size of the `FAKE_DISK_FILE`
+  through `truncate` in case the file does not exist.
+
+- `FAKE_DISK_DEV` (defaults to `/dev/fake`) the device node under `/dev` that
+  should be provided for the disk. This will be a symlink to the `/dev/loop<N>`
+  loopback device.
+

--- a/CentOS/fake-disk.sh
+++ b/CentOS/fake-disk.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+#
+# Create a fake-disk for use with Gluster.
+#
+# Copyright (c) 2018 Red Hat, Inc. <http://www.redhat.com>
+#
+# This file is part of GlusterFS.
+#
+# This file is licensed to you under your choice of the GNU Lesser
+# General Public License, version 3 or any later version (LGPLv3 or
+# later), or the GNU General Public License, version 2 (GPLv2), in all
+# cases as published by the Free Software Foundation.
+#
+
+# Note: environment variables might need to listed in the systemd .service as
+# well, see PassEnvironment in gluster-fake-disk.service and systemd.exec(5).
+#
+# Set the USE_FAKE_DISK environment variable in the container deployment
+#USE_FAKE_DISK=1
+# You should also have a bind-mount for /srv in case data is expected to stay
+# available after restarting the glusterfs-server container.
+FAKE_DISK_FILE=${FAKE_DISK_FILE:-/srv/fake-disk.img}
+FAKE_DISK_SIZE=${FAKE_DISK_SIZE:-10G}
+FAKE_DISK_DEV=${FAKE_DISK_DEV:-/dev/fake}
+
+# Create the FAKE_DISK_FILE with fallocate, but only do so if it does not exist
+# yet.
+create_fake_disk_file () {
+  [ -e "${FAKE_DISK_FILE}" ] && return 0
+  truncate --size "${FAKE_DISK_SIZE}" "${FAKE_DISK_FILE}"
+}
+
+# Setup a loop device for the FAKE_DISK_FILE, and create a symlink to /dev/fake
+# so that it has a stable name and can be used by other components (/dev/loop*
+# is numbered based on other existing loop devices).
+setup_fake_disk () {
+  local fakedev
+
+  fakedev=$(losetup --find --show "${FAKE_DISK_FILE}")
+  [ -e "${fakedev}" ] && ln -fs "${fakedev}" "${FAKE_DISK_DEV}"
+}
+
+if [ -n "${USE_FAKE_DISK}" ]
+then
+  if ! create_fake_disk_file
+  then
+    echo "failed to create a fake disk at ${FAKE_DISK_FILE}"
+    exit 1
+  fi
+
+  if ! setup_fake_disk
+  then
+    echo "failed to setup loopback device for ${FAKE_DISK_FILE}"
+    exit 1
+  fi
+fi

--- a/CentOS/gluster-fake-disk.service
+++ b/CentOS/gluster-fake-disk.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Setup fake disk for use with Gluster
+Before=gluster-setup.service
+
+[Service]
+Type=oneshot
+PassEnvironment=USE_FAKE_DISK FAKE_DISK_FILE FAKE_DISK_SIZE FAKE_DISK_DEV
+ExecStart=/usr/libexec/gluster/fake-disk.sh
+
+[Install]
+WantedBy=multi-user.target

--- a/Fedora/Dockerfile
+++ b/Fedora/Dockerfile
@@ -26,6 +26,8 @@ VOLUME [ "/sys/fs/cgroup/" ]
 ADD https://github.com/gluster/gluster-containers/blob/master/README.md /README.md
 
 COPY gluster-setup.sh gluster-brickmultiplex.service gluster-brickmultiplex.sh gluster-setup.service /
+COPY gluster-fake-disk.service /etc/systemd/system/gluster-fake-disk.service
+COPY fake-disk.sh /usr/libexec/gluster/fake-disk.sh
 
 RUN dnf -y update && \
     sed -i "s/LANG/\#LANG/g" /etc/locale.conf && \
@@ -46,6 +48,7 @@ RUN dnf -y update && \
     mv /gluster-brickmultiplex.service /etc/systemd/system/gluster-brickmultiplex.service && \
     mv /gluster-brickmultiplex.sh /usr/sbin/gluster-brickmultiplex.sh && \
     mv /gluster-setup.service /etc/systemd/system/gluster-setup.service && \
+    chmod 755 /usr/libexec/gluster/fake-disk.sh && \
     chmod 644 /etc/systemd/system/gluster-setup.service && \
     chmod 500 /usr/sbin/gluster-setup.sh && \
     ln -s /usr/sbin/gluster-setup.sh /usr/sbin/setup.sh && \
@@ -57,6 +60,7 @@ RUN dnf -y update && \
     systemctl disable nfs-server.service && \
     systemctl enable rpcbind.service && \
     systemctl enable sshd.service && \
+    systemctl enable gluster-fake-disk.service && \
     systemctl enable gluster-setup.service && \
     systemctl enable gluster-brickmultiplex.service && \
     systemctl enable glusterd.service && \

--- a/Fedora/README.md
+++ b/Fedora/README.md
@@ -10,3 +10,28 @@ GlusterFS on Fedora
 ## Description
 
 GlusterFS is a distributed and scalable network filesystem. Using common, off-the-shelf hardware you can create large, distributed storage solutions for media streaming, data analysis, and other data- and bandwidth-intensive tasks.
+
+## Support for fake disks
+
+This container offers several configuration options that make it easier to test
+the functionality. It is possible to configure a fake disk so that there is no
+requirement for additional block devices on the container host. The container
+has a `gluster-fake-disk` service that consumes the following environment
+variables:
+
+- `USE_FAKE_DISK` (default is empty) when set to a non-empty value, setup a
+  fake disk. The other environment variables have defaults and do not need to
+  be set.
+
+- `FAKE_DISK_FILE` (defaults to `/srv/fake-disk.img`) the fake disk will be
+  backed by this file. To have persistent storage, make sure to have the
+  directory where this file is located bind-mounted as a volume in the
+  container.
+
+- `FAKE_DISK_SIZE` (defaults to `10G`) sets the size of the `FAKE_DISK_FILE`
+  through `truncate` in case the file does not exist.
+
+- `FAKE_DISK_DEV` (defaults to `/dev/fake`) the device node under `/dev` that
+  should be provided for the disk. This will be a symlink to the `/dev/loop<N>`
+  loopback device.
+

--- a/Fedora/fake-disk.sh
+++ b/Fedora/fake-disk.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+#
+# Create a fake-disk for use with Gluster.
+#
+# Copyright (c) 2018 Red Hat, Inc. <http://www.redhat.com>
+#
+# This file is part of GlusterFS.
+#
+# This file is licensed to you under your choice of the GNU Lesser
+# General Public License, version 3 or any later version (LGPLv3 or
+# later), or the GNU General Public License, version 2 (GPLv2), in all
+# cases as published by the Free Software Foundation.
+#
+
+# Note: environment variables might need to listed in the systemd .service as
+# well, see PassEnvironment in gluster-fake-disk.service and systemd.exec(5).
+#
+# Set the USE_FAKE_DISK environment variable in the container deployment
+#USE_FAKE_DISK=1
+# You should also have a bind-mount for /srv in case data is expected to stay
+# available after restarting the glusterfs-server container.
+FAKE_DISK_FILE=${FAKE_DISK_FILE:-/srv/fake-disk.img}
+FAKE_DISK_SIZE=${FAKE_DISK_SIZE:-10G}
+FAKE_DISK_DEV=${FAKE_DISK_DEV:-/dev/fake}
+
+# Create the FAKE_DISK_FILE with fallocate, but only do so if it does not exist
+# yet.
+create_fake_disk_file () {
+  [ -e "${FAKE_DISK_FILE}" ] && return 0
+  truncate --size "${FAKE_DISK_SIZE}" "${FAKE_DISK_FILE}"
+}
+
+# Setup a loop device for the FAKE_DISK_FILE, and create a symlink to /dev/fake
+# so that it has a stable name and can be used by other components (/dev/loop*
+# is numbered based on other existing loop devices).
+setup_fake_disk () {
+  local fakedev
+
+  fakedev=$(losetup --find --show "${FAKE_DISK_FILE}")
+  [ -e "${fakedev}" ] && ln -fs "${fakedev}" "${FAKE_DISK_DEV}"
+}
+
+if [ -n "${USE_FAKE_DISK}" ]
+then
+  if ! create_fake_disk_file
+  then
+    echo "failed to create a fake disk at ${FAKE_DISK_FILE}"
+    exit 1
+  fi
+
+  if ! setup_fake_disk
+  then
+    echo "failed to setup loopback device for ${FAKE_DISK_FILE}"
+    exit 1
+  fi
+fi

--- a/Fedora/gluster-fake-disk.service
+++ b/Fedora/gluster-fake-disk.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Setup fake disk for use with Gluster
+Before=gluster-setup.service
+
+[Service]
+Type=oneshot
+PassEnvironment=USE_FAKE_DISK FAKE_DISK_FILE FAKE_DISK_SIZE FAKE_DISK_DEV
+ExecStart=/usr/libexec/gluster/fake-disk.sh
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
When the environment variable USE_FAKE_DISK is set, and the
FAKE_DISK_FILE does not exist yet, it will be created. FAKE_DISK_FILE
is set to /srv/fake-disk.img by default. When it is expected for the
disk to be persistent over container restarts, it is needed to have the
directory where the disk file is located to be bind-mounted into the
container (a volume providing /srv).

By default the size of the fake dist is set to 10GB. This is a sparse
file allocated with `fallocate`. If a different size is required, the
FAKE_DISK_SIZE environment variable can be used to change this.

The disk file is setup with `losetup` and will be available for use
through /dev/loop* device nodes. Depending on the environment, the
number of the loop device may change. In order to privide a stable name,
FAKE_DISK_DEV can be used. /dev/fake is the default for this.