### PR TITLE
Update to version 4.1.x

### DIFF
--- a/CentOS/Dockerfile
+++ b/CentOS/Dockerfile
@@ -6,15 +6,15 @@ ENV container docker
 
 LABEL architecture="x86_64" \
       name="gluster/gluster-centos" \
-      version="4.0" \
+      version="4.1" \
       vendor="CentOS Community" \
-      summary="This image has a running glusterfs service ( CentOS 7 + Gluster 4.0)" \
-      io.k8s.display-name="Gluster 4.0 based on CentOS 7" \
+      summary="This image has a running glusterfs service ( CentOS 7 + Gluster 4.1)" \
+      io.k8s.display-name="Gluster 4.1 based on CentOS 7" \
       io.k8s.description="Gluster Image is based on CentOS Image which is a scalable network filesystem. Using common off-the-shelf hardware, you can create large, distributed storage solutions for media streaming, data analysis, and other data- and bandwidth-intensive tasks." \
       description="Gluster Image is based on CentOS Image which is a scalable network filesystem. Using common off-the-shelf hardware, you can create large, distributed storage solutions for media streaming, data analysis, and other data- and bandwidth-intensive tasks." \
       io.openshift.tags="gluster,glusterfs,glusterfs-centos"
 
-RUN yum --setopt=tsflags=nodocs -y update && yum install -y centos-release-gluster40 && yum clean all && \
+RUN yum --setopt=tsflags=nodocs -y update && yum install -y centos-release-gluster41 && yum clean all && \
 (cd /lib/systemd/system/sysinit.target.wants/; for i in *; do [ $i == systemd-tmpfiles-setup.service ] || rm -f $i; done) && \
 rm -f /lib/systemd/system/multi-user.target.wants/* &&\
 rm -f /etc/systemd/system/*.wants/* &&\

--- a/gluster-client/Dockerfile
+++ b/gluster-client/Dockerfile
@@ -4,10 +4,10 @@ MAINTAINER Humble Devassy Chirammal  <hchiramm@redhat.com>
 
 LABEL architecture="x86_64" \
       name="gluster/glusterfs-client" \
-      version="3.10" \
+      version="4.1" \
       vendor="Red Hat, Inc" \
-      summary="This image has a running glusterfs service ( Fedora + Gluster 3.10 client)" \
-      io.k8s.display-name="Gluster 3.10 client based on Fedora" \
+      summary="This image has a running glusterfs service ( Fedora + Gluster 4.1 client)" \
+      io.k8s.display-name="Gluster 4.1 client based on Fedora" \
       io.k8s.description="Gluster Client Image is based on Fedora Image which is used to mount a glusterfs volume." \
       description="Gluster Client Image is based on Fedora Image which is used to mount a glusterfs volume." \
       io.openshift.tags="gluster,glusterfs,glusterfs-client"


### PR DESCRIPTION
We needed to update to gluster 4.1.x in order to resolve [a bug we were experiencing](https://bugzilla.redhat.com/show_bug.cgi?id=1576927) but found that these official images have not been updated, despite the unceremonious end-of-lifing that version 4.0.x received in June.

I was able to push a `cedardevs/gluster-centos:4.1` image based on this code and it is running successfully in our cluster. I was also able to build the other 3 images successfully, and `make test` passed locally.

I believe this is all that needs to be done to update the images, **but I could certainly be mistaken, so please check my work.** I'm especially unfamiliar with swift and the `gluster-s3object` image.

Also note that I did not modify the readme at all since I don't know how you'll want to tag the images in the docker registry.

Thanks!