### PR TITLE
Do not run udev and lvmetad inside the container

### DIFF
--- a/CentOS/Dockerfile
+++ b/CentOS/Dockerfile
@@ -44,12 +44,19 @@ sed -i '/Port 22/c\Port 2222' /etc/ssh/sshd_config && \
 sed -i 's/Requires\=rpcbind\.service//g' /usr/lib/systemd/system/glusterd.service && \
 sed -i 's/rpcbind\.service/gluster-setup\.service/g' /usr/lib/systemd/system/glusterd.service && \
 sed -i 's/rpcbind\.service//g' /usr/lib/systemd/system/gluster-blockd.service && \
-sed -i 's/ENV{DM_UDEV_DISABLE_OTHER_RULES_FLAG}=="1", ENV{SYSTEMD_READY}="0"/ENV{DM_UDEV_DISABLE_OTHER_RULES_FLAG}=="1", GOTO="systemd_end"/g' /usr/lib/udev/rules.d/99-systemd.rules && \
 mkdir -p /etc/glusterfs_bkp /var/lib/glusterd_bkp /var/log/glusterfs_bkp &&\
 cp -r /etc/glusterfs/* /etc/glusterfs_bkp &&\
 cp -r /var/lib/glusterd/* /var/lib/glusterd_bkp &&\
 cp -r /var/log/glusterfs/* /var/log/glusterfs_bkp && \
 mkdir -p /var/log/core;
+
+# do not run udev (if needed, bind-mount /run/udev instead?)
+RUN true \
+    && systemctl mask systemd-udev-trigger.service \
+    && systemctl mask systemd-udevd.service \
+    && systemctl mask systemd-udevd.socket \
+    && systemctl mask systemd-udevd-kernel.socket \
+    && true
 
 # use lvmetad from the host, dont run it in the container
 # don't wait for udev to manage the /dev entries, disable udev_sync, udev_rules in lvm.conf

--- a/CentOS/Dockerfile
+++ b/CentOS/Dockerfile
@@ -49,8 +49,17 @@ mkdir -p /etc/glusterfs_bkp /var/lib/glusterd_bkp /var/log/glusterfs_bkp &&\
 cp -r /etc/glusterfs/* /etc/glusterfs_bkp &&\
 cp -r /var/lib/glusterd/* /var/lib/glusterd_bkp &&\
 cp -r /var/log/glusterfs/* /var/log/glusterfs_bkp && \
-sed -i.save -e "s#udev_sync = 1#udev_sync = 0#" -e "s#udev_rules = 1#udev_rules = 0#" -e "s#use_lvmetad = 1#use_lvmetad = 0#" /etc/lvm/lvm.conf && \
 mkdir -p /var/log/core;
+
+# use lvmetad from the host, dont run it in the container
+# don't wait for udev to manage the /dev entries, disable udev_sync, udev_rules in lvm.conf
+VOLUME [ "/run/lvm" ]
+RUN true \
+    && systemctl mask lvm2-lvmetad.service \
+    && systemctl mask lvm2-lvmetad.socket \
+    && sed -i 's/^\sudev_rules\s*=\s*1/udev_rules = 0/' /etc/lvm/lvm.conf \
+    && sed -i 's/^\sudev_sync\s*=\s*1/udev_sync= 0/' /etc/lvm/lvm.conf \
+    && true
 
 VOLUME [ "/sys/fs/cgroup" ]
 ADD gluster-setup.service /etc/systemd/system/gluster-setup.service


### PR DESCRIPTION
There have been several deadlock observed related to LVM. It was noticed
that two `lvmetad` services were running, and accessing the block
devices. The `lvmetad` process inside the container should not get
started. Using `lvmetad` enhances performance, and that can become
important when there are many LVs on the system. The LVM configuration
inside the container should use the `lvmetad` process that is running on
the host.

A very similar problem could happen with udev. LVM inside the container
already was configured to not use udev (`udev_rules=0`), but the
services were still being started. If udev is needed by the host, it
should run there and not in the container.

BUG: https://bugzilla.redhat.com/1536511
BUG: https://bugzilla.redhat.com/1627104