### PR TITLE
add a status probe script to CentOS gluster container

### DIFF
--- a/CentOS/Dockerfile
+++ b/CentOS/Dockerfile
@@ -58,6 +58,7 @@ ADD gluster-setup.sh /usr/sbin/gluster-setup.sh
 ADD gluster-block-setup.service /etc/systemd/system/gluster-block-setup.service
 ADD gluster-block-setup.sh /usr/sbin/gluster-block-setup.sh
 ADD update-params.sh /usr/local/bin/update-params.sh
+ADD status-probe.sh /usr/local/bin/status-probe.sh
 ADD tcmu-runner-params /etc/sysconfig/tcmu-runner-params
 ADD gluster-check-diskspace.service  /etc/systemd/system/gluster-check-diskspace.service
 ADD check_diskspace.sh /usr/local/bin/check_diskspace.sh
@@ -68,6 +69,7 @@ chmod 500 /usr/sbin/gluster-setup.sh && \
 chmod 644 /etc/systemd/system/gluster-block-setup.service && \
 chmod 500 /usr/sbin/gluster-block-setup.sh && \
 chmod +x /usr/local/bin/update-params.sh && \
+chmod +x /usr/local/bin/status-probe.sh && \
 chmod +x /usr/local/bin/check_diskspace.sh && \
 systemctl disable nfs-server.service && \
 systemctl mask getty.target && \

--- a/CentOS/status-probe.sh
+++ b/CentOS/status-probe.sh
@@ -33,7 +33,7 @@ case "$mode" in
         fi
         require systemctl -q is-active glusterd.service
         
-        if [[ "$GLUSTER_BLOCKD_STATUS_PROBE_SKIP" -ne 1 ]]; then
+        if [[ "$GLUSTER_BLOCKD_STATUS_PROBE_ENABLE" -eq 1 ]]; then
             require systemctl -q is-active gluster-blockd.service
         fi
 

--- a/CentOS/status-probe.sh
+++ b/CentOS/status-probe.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+#
+# Return overall status of the glusterfs container
+#
+
+require() {
+    if ! "$@" ; then
+        echo "failed check: $*" >&2
+        exit 1
+    fi
+}
+
+filesystem_used_under_limit() {
+    path="$1"
+    max_used="$2"
+    curr_used="$(df --output=pcent "$path" | tail -n1  | awk '{print $1}')"
+    curr_used="${curr_used%?}"
+    [[ "$curr_used" -lt "$max_used" ]]
+}
+
+mode="$1"
+case "$mode" in
+    -h|--help|help)
+        echo "Return overall container status"
+        echo "    $0 [readiness|liveness]"
+        exit 0
+    ;;
+    # currently the liveness and readiness check is the same
+    # it does not always have to be this way
+    ready|readiness|live|liveness|"")
+        if [[ -z "$mode" ]] ; then
+            echo "warning: no mode provided. Assuming liveness probe" >&2
+        fi
+        require systemctl -q is-active glusterd.service
+        require systemctl -q is-active gluster-blockd.service
+        require filesystem_used_under_limit "/var/lib/glusterd" 99
+    ;;
+    *)
+        echo "error: unknown mode $mode" >&2
+        exit 2
+    ;;
+esac

--- a/CentOS/status-probe.sh
+++ b/CentOS/status-probe.sh
@@ -32,7 +32,11 @@ case "$mode" in
             echo "warning: no mode provided. Assuming liveness probe" >&2
         fi
         require systemctl -q is-active glusterd.service
-        require systemctl -q is-active gluster-blockd.service
+        
+        if [[ "$GLUSTER_BLOCKD_STATUS_PROBE_SKIP" -ne 1 ]]; then
+            require systemctl -q is-active gluster-blockd.service
+        fi
+
         require filesystem_used_under_limit "/var/lib/glusterd" 99
     ;;
     *)


### PR DESCRIPTION
This PR overlaps with and obsoletes PR #98. It has the advantage of handling both liveness and readiness checks via a command argument.
Like the previous effort it checks the status of the glusterd service and that there is free space on /var/lib/glusterd. It adds a check for the gluster-blockd service.

Corresponding changes will be needed outside of the containers to call this script rather than probing only the status of the glusterd service.