### PR TITLE
Remove /dev bind mount from example

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ This way all the gluster containers started will be time synchronized.
 Now run the following command:
 
 ~~~
-$ docker run -v /etc/glusterfs:/etc/glusterfs:z -v /var/lib/glusterd:/var/lib/glusterd:z -v /var/log/glusterfs:/var/log/glusterfs:z -v /sys/fs/cgroup:/sys/fs/cgroup:ro -d --privileged=true --net=host -v /dev/:/dev gluster/gluster-centos
+$ docker run -v /etc/glusterfs:/etc/glusterfs:z -v /var/lib/glusterd:/var/lib/glusterd:z -v /var/log/glusterfs:/var/log/glusterfs:z -v /sys/fs/cgroup:/sys/fs/cgroup:ro -d --privileged=true --net=host gluster/gluster-centos
 ~~~
 
 ( is either gluster-fedora or gluster-centos as per the configurations so far)


### PR DESCRIPTION
There is no need to bind-mount /dev when the container is privileged,
the container runtime provides everything in /dev that Gluster expects.

Fixes: https://bugzilla.redhat.com/1651270