### PR TITLE
Fix copy from backup

### DIFF
--- a/CentOS/gluster-setup.sh
+++ b/CentOS/gluster-setup.sh
@@ -27,7 +27,7 @@ main () {
           echo "$i is not empty"
     else
           bkp=$i"_bkp"
-          cp -r $bkp/* $i
+          cp -af $bkp/* $i
           if [ $? -eq 1 ]
           then
                 echo "Failed to copy $i"

--- a/Fedora/gluster-setup.sh
+++ b/Fedora/gluster-setup.sh
@@ -27,7 +27,7 @@ main () {
           echo "$i is not empty"
     else
           bkp=$i"_bkp"
-          cp -r $bkp/* $i
+          cp -af $bkp/* $i
           if [ $? -eq 1 ]
           then
                 echo "Failed to copy $i"


### PR DESCRIPTION
Avoid recursive copy and use archive option during copy.

See the below example, we have issue while doing copy of directory
which contains multiple files.

recursive copy here tries to copy files to a directory which is
non-existent and hence throws a error.
    
While using archive option, files (or) directories are copied as is
to the destination.

====================================================
Directory having files:

root@gant testing$ mkdir test
root@gant testing$ touch test/t1
root@gant testing$ touch test/t2
root@gant testing$ touch test/t3

// just to confirm no such directory exists:
root@gant testing$ ls  /tmp/targettest
ls: cannot access '/tmp/targettest': No such file or directory

root@gant testing$
root@gant testing$
root@gant testing$ cp -r test/* /tmp/targettest
cp: target '/tmp/targettest' is not a directory
root@gant testing$

================================================
Directory having another directory:

root@gant testing$ mkdir  test
root@gant testing$
root@gant testing$
root@gant testing$ mkdir test/testdir
root@gant testing$

// just to confirm no such directory exists:
root@gant testing$ ls /tmp/testdir
ls: cannot access '/tmp/testdir': No such file or directory

root@gant testing$ cp -r test/* /tmp/

root@gant testing$ ls /tmp/testdir -ld
drwxr-xr-x 2 root root 40 Nov 30 19:20 /tmp/testdir

====================================================

Signed-off-by: Saravanakumar Arumugam <sarumuga@redhat.com>