### PR TITLE
gluster-setup: retry in case mounting fails

### DIFF
--- a/CentOS/gluster-setup.sh
+++ b/CentOS/gluster-setup.sh
@@ -39,14 +39,14 @@ main () {
 
   if test "$(ls $GLUSTERFS_LOG_CONT_DIR)"
   then
-            echo "" > $GLUSTERFS_LOG_CONT_DIR/brickattr
-            echo "" > $GLUSTERFS_LOG_CONT_DIR/failed_bricks
-            echo "" > $GLUSTERFS_LOG_CONT_DIR/lvscan
-            echo "" > $GLUSTERFS_LOG_CONT_DIR/mountfstab
+        true > $GLUSTERFS_LOG_CONT_DIR/brickattr
+        true > $GLUSTERFS_LOG_CONT_DIR/failed_bricks
+        true > $GLUSTERFS_LOG_CONT_DIR/lvscan
+        true > $GLUSTERFS_LOG_CONT_DIR/mountfstab
   else
         mkdir $GLUSTERFS_LOG_CONT_DIR
-        echo "" > $GLUSTERFS_LOG_CONT_DIR/brickattr
-        echo "" > $GLUSTERFS_LOG_CONT_DIR/failed_bricks
+        true > $GLUSTERFS_LOG_CONT_DIR/brickattr
+        true > $GLUSTERFS_LOG_CONT_DIR/failed_bricks
   fi
   if test "$(ls $GLUSTERFS_CUSTOM_FSTAB)"
   then
@@ -85,7 +85,7 @@ main () {
                    sleep 0.5
              fi
         done
-        if [ "$(wc -l $GLUSTERFS_LOG_CONT_DIR/failed_bricks )" -gt 1 ]
+        if [ "$(wc -l $GLUSTERFS_LOG_CONT_DIR/failed_bricks )" -gt 0 ]
         then
               vgscan --mknodes > $GLUSTERFS_LOG_CONT_DIR/vgscan_mknodes
               sleep 10

--- a/CentOS/gluster-setup.sh
+++ b/CentOS/gluster-setup.sh
@@ -58,12 +58,14 @@ main () {
 
         mount -a --fstab $GLUSTERFS_CUSTOM_FSTAB &> $GLUSTERFS_LOG_CONT_DIR/mountfstab
         sts=$?
-        if [ $sts -ne 0 ]
+        if [ $sts -eq 0 ]
         then
-              echo "mount command exited with code ${sts}" >> $GLUSTERFS_LOG_CONT_DIR/mountfstab
-              exit 1
+              echo "Mount command Successful" >> $GLUSTERFS_LOG_CONT_DIR/mountfstab
+              exit 0
         fi
-        echo "Mount command Successful" >> $GLUSTERFS_LOG_CONT_DIR/mountfstab
+
+        # mounting (some of) the bricks failed, retry
+        echo "mount command exited with code ${sts}" >> $GLUSTERFS_LOG_CONT_DIR/mountfstab
         sleep 40
         cut -f 2 -d " " $GLUSTERFS_CUSTOM_FSTAB | while read -r line
         do

--- a/CentOS/gluster-setup.sh
+++ b/CentOS/gluster-setup.sh
@@ -85,7 +85,7 @@ main () {
                    sleep 0.5
              fi
         done
-        if [ "$(wc -l $GLUSTERFS_LOG_CONT_DIR/failed_bricks )" -gt 0 ]
+        if [ "$(wc -l < $GLUSTERFS_LOG_CONT_DIR/failed_bricks)" -gt 0 ]
         then
               vgscan --mknodes > $GLUSTERFS_LOG_CONT_DIR/vgscan_mknodes
               sleep 10

--- a/Fedora/gluster-setup.sh
+++ b/Fedora/gluster-setup.sh
@@ -39,14 +39,14 @@ main () {
 
   if test "$(ls $GLUSTERFS_LOG_CONT_DIR)"
   then
-            echo "" > $GLUSTERFS_LOG_CONT_DIR/brickattr
-            echo "" > $GLUSTERFS_LOG_CONT_DIR/failed_bricks
-            echo "" > $GLUSTERFS_LOG_CONT_DIR/lvscan
-            echo "" > $GLUSTERFS_LOG_CONT_DIR/mountfstab
+        true > $GLUSTERFS_LOG_CONT_DIR/brickattr
+        true > $GLUSTERFS_LOG_CONT_DIR/failed_bricks
+        true > $GLUSTERFS_LOG_CONT_DIR/lvscan
+        true > $GLUSTERFS_LOG_CONT_DIR/mountfstab
   else
         mkdir $GLUSTERFS_LOG_CONT_DIR
-        echo "" > $GLUSTERFS_LOG_CONT_DIR/brickattr
-        echo "" > $GLUSTERFS_LOG_CONT_DIR/failed_bricks
+        true > $GLUSTERFS_LOG_CONT_DIR/brickattr
+        true > $GLUSTERFS_LOG_CONT_DIR/failed_bricks
   fi
   if test "$(ls $GLUSTERFS_CUSTOM_FSTAB)"
   then
@@ -83,7 +83,7 @@ main () {
                    sleep 0.5
              fi
         done
-        if [ $(cat $GLUSTERFS_LOG_CONT_DIR/failed_bricks | wc -l) -gt 1 ]
+        if [ $(cat $GLUSTERFS_LOG_CONT_DIR/failed_bricks | wc -l) -gt 0 ]
         then
               vgscan --mknodes > $GLUSTERFS_LOG_CONT_DIR/vgscan_mknodes
               sleep 10

--- a/Fedora/gluster-setup.sh
+++ b/Fedora/gluster-setup.sh
@@ -56,12 +56,14 @@ main () {
         lvscan > $GLUSTERFS_LOG_CONT_DIR/lvscan
         mount -a --fstab $GLUSTERFS_CUSTOM_FSTAB &> $GLUSTERFS_LOG_CONT_DIR/mountfstab
         sts=$?
-        if [ $sts -ne 0 ]
+        if [ $sts -eq 0 ]
         then
-              echo "mount command exited with code ${sts}" >> $GLUSTERFS_LOG_CONT_DIR/mountfstab
-              exit 1
+              echo "Mount command Successful" >> $GLUSTERFS_LOG_CONT_DIR/mountfstab
+              exit 0
         fi
-        echo "Mount command Successful" >> $GLUSTERFS_LOG_CONT_DIR/mountfstab
+
+        # mounting (some of) the bricks failed, retry
+        echo "mount command exited with code ${sts}" >> $GLUSTERFS_LOG_CONT_DIR/mountfstab
         sleep 40
         cat $GLUSTERFS_CUSTOM_FSTAB|cut -f 2 -d " " | while read line
         do

--- a/Fedora/gluster-setup.sh
+++ b/Fedora/gluster-setup.sh
@@ -83,7 +83,7 @@ main () {
                    sleep 0.5
              fi
         done
-        if [ $(cat $GLUSTERFS_LOG_CONT_DIR/failed_bricks | wc -l) -gt 0 ]
+        if [ "$(wc -l < $GLUSTERFS_LOG_CONT_DIR/failed_bricks)" -gt 0 ]
         then
               vgscan --mknodes > $GLUSTERFS_LOG_CONT_DIR/vgscan_mknodes
               sleep 10


### PR DESCRIPTION
Currently gluster-setup.sh aborts when 'mount' returns an error. In
certain cases LVM/LVs are not available yet, and mounting the devices is
not possible. The script already tries to account for that, but a
mistake prevents the retry from being reached.

With this change the gluster-setup.sh script exits only when mounting
succeeds, and will do the retry (including 'vgscan --mknods') when a
failure occured.

Signed-off-by: Niels de Vos <ndevos@redhat.com>