### PR TITLE
centos: if a "host dev" exists bind mount it over /dev

### DIFF
--- a/CentOS/update-params.sh
+++ b/CentOS/update-params.sh
@@ -5,6 +5,7 @@
 : ${TCMU_LOGDIR:=/var/log/glusterfs/gluster-block}
 : ${GB_GLFS_LRU_COUNT:=15}
 : ${GLUSTER_BLOCK_ENABLED:=TRUE}
+: ${HOST_DEV_DIR:=/mnt/host-dev}
 
 if [ "$GLUSTER_BLOCK_ENABLED" == TRUE ]; then
         echo "Enabling gluster-block service and updating env. variables"
@@ -23,6 +24,12 @@ else
         echo "Disabling gluster-block service"
         systemctl disable gluster-block-setup.service
         systemctl disable gluster-blockd.service
+fi
+
+if [ -c "${HOST_DEV_DIR}/zero" ] && [ -c "${HOST_DEV_DIR}/null" ]; then
+    # looks like an alternate "host dev" has been provided
+    # to the container. Use that as our /dev ongoing
+    mount --rbind "${HOST_DEV_DIR}" /dev
 fi
 
 # Hand off to CMD


### PR DESCRIPTION
This is a work around for containerization systems that
have a problem with us using the host's /dev directly but we
need a dynamic dev populated for devices, lvs and gluster-block
support.
Eventually it would be nice to move away from needing the
host's /dev but that day is not here yet.


# Note

This checks if something that looks like a "/dev" is mounted in the container and bind mounts (recursively) that over the existing /dev. I'm currently using the environment variable HOST_DEV_DIR and default of /mnt/host-dev. I'm not wedded to these names and welcome discussions over what the dfaults should be.
We may also want to make matching changes to our templates as needed.

This has been tested on a cluster using cri-o and both "exec -it/rsh" commands and gluster-block appeared to work with a hand executed version of this. Let's discuss if this is the best short term fix for these issues.