### PR TITLE
Resolves #117 Attempts to retry failed mounts of bricks

### DIFF
--- a/CentOS/gluster-setup.sh
+++ b/CentOS/gluster-setup.sh
@@ -58,12 +58,17 @@ main () {
 
         mount -a --fstab $GLUSTERFS_CUSTOM_FSTAB &> $GLUSTERFS_LOG_CONT_DIR/mountfstab
         sts=$?
-        if [ $sts -ne 0 ]
+        if [ $sts -eq 1 -o $sts -eq 2 -o $sts -eq 4 ]
         then
               echo "mount command exited with code ${sts}" >> $GLUSTERFS_LOG_CONT_DIR/mountfstab
               exit 1
         fi
-        echo "Mount command Successful" >> $GLUSTERFS_LOG_CONT_DIR/mountfstab
+	if [ $sts -ne 0 ]
+	then
+	      echo "mount command non-fatal error with ${sts}" >> $GLUSTERFS_LOG_CONT_DIR/mountfstab
+	else
+              echo "Mount command Successful" >> $GLUSTERFS_LOG_CONT_DIR/mountfstab
+	fi
         sleep 40
         cut -f 2 -d " " $GLUSTERFS_CUSTOM_FSTAB | while read -r line
         do
@@ -83,7 +88,7 @@ main () {
                    sleep 0.5
              fi
         done
-        if [ "$(wc -l $GLUSTERFS_LOG_CONT_DIR/failed_bricks )" -gt 1 ]
+        if [ "$((cat $GLUSTERFS_LOG_CONT_DIR/failed_bricks | wc -l) )" -gt 1 ]
         then
               vgscan --mknodes > $GLUSTERFS_LOG_CONT_DIR/vgscan_mknodes
               sleep 10


### PR DESCRIPTION
After the update in commit 2e2e284, gluster-setup.sh no longer attempts to mount failed bricks.

* checks for the return codes 1, 2, and 4 which is fatal
* logs successful mount
* if unsuccessful, allows script to continue to attempt the retry logic below.

According to the [man page][1] RETURN CODE 1 is incorrect permissions or invocation (bad parameters). The previous commit attempted to only test for that error, which if continuing in the script logic allows the glusterd pod/container to attempt to identify the failed bricks, and try various tricks to mount them.

[1]: https://linux.die.net/man/8/mount

This change tests for RETURN CODE 1, 2, and 4 - which should cover most fatal errors, and still allow the script to attempt to mount failed bricks using the logic below that test.

Also, the test at the end:
```bash
        if [ "$((cat $GLUSTERFS_LOG_CONT_DIR/failed_bricks | wc -l) )" -gt 1 ]
```
works better than the `wc -l $GLUSTERFS_LOG_CONT_DIR/failed_bricks` it replaces, as the `wc` command appends the filename, which breaks the number test `-gt`. Therefore, the `cat | wc` syntax works better as `wc` does not print the filename when used on stdin, and thus it does not break the `-gt` test.