### PR TITLE
Revert "Use env. variable GLUSTER_BLOCK_ENABLED to enable/disable glu…

### DIFF
--- a/CentOS/Dockerfile
+++ b/CentOS/Dockerfile
@@ -94,6 +94,8 @@ systemctl disable nfs-server.service && \
 systemctl mask getty.target && \
 systemctl enable gluster-fake-disk.service && \
 systemctl enable gluster-setup.service && \
+systemctl enable gluster-block-setup.service && \
+systemctl enable gluster-blockd.service && \
 systemctl enable glusterd.service && \
 systemctl enable gluster-check-diskspace.service
 

--- a/CentOS/update-params.sh
+++ b/CentOS/update-params.sh
@@ -4,27 +4,17 @@
 : ${GB_LOGDIR:=/var/log/glusterfs/gluster-block}
 : ${TCMU_LOGDIR:=/var/log/glusterfs/gluster-block}
 : ${GB_GLFS_LRU_COUNT:=15}
-: ${GLUSTER_BLOCK_ENABLED:=TRUE}
 : ${HOST_DEV_DIR:=/mnt/host-dev}
 
-if [ "$GLUSTER_BLOCK_ENABLED" == TRUE ]; then
-        echo "Enabling gluster-block service and updating env. variables"
-        systemctl enable gluster-block-setup.service
-        systemctl enable gluster-blockd.service
+echo "env variable is set. Update in gluster-blockd.service"
+#FIXME To update in environment file
+sed -i '/GB_GLFS_LRU_COUNT=/s/GB_GLFS_LRU_COUNT=.*/'GB_GLFS_LRU_COUNT="$GB_GLFS_LRU_COUNT"\"'/'  /usr/lib/systemd/system/gluster-blockd.service
+sed -i '/EnvironmentFile/i Environment="GB_LOGDIR='$GB_LOGDIR'"' /usr/lib/systemd/system/gluster-blockd.service
 
-        #FIXME To update in environment file
-        sed -i '/GB_GLFS_LRU_COUNT=/s/GB_GLFS_LRU_COUNT=.*/'GB_GLFS_LRU_COUNT="$GB_GLFS_LRU_COUNT"\"'/'  /usr/lib/systemd/system/gluster-blockd.service
-        sed -i '/EnvironmentFile/i Environment="GB_LOGDIR='$GB_LOGDIR'"' /usr/lib/systemd/system/gluster-blockd.service
+sed -i "s#TCMU_LOGDIR=.*#TCMU_LOGDIR='$TCMU_LOGDIR'#g" /etc/sysconfig/tcmu-runner-params
 
-        sed -i "s#TCMU_LOGDIR=.*#TCMU_LOGDIR='$TCMU_LOGDIR'#g" /etc/sysconfig/tcmu-runner-params
-
-        sed -i '/ExecStart/i EnvironmentFile=-/etc/sysconfig/tcmu-runner-params' /usr/lib/systemd/system/tcmu-runner.service
-        sed -i  '/tcmu-log-dir=/s/tcmu-log-dir.*/tcmu-log-dir $TCMU_LOGDIR/' /usr/lib/systemd/system/tcmu-runner.service
-else
-        echo "Disabling gluster-block service"
-        systemctl disable gluster-block-setup.service
-        systemctl disable gluster-blockd.service
-fi
+sed -i '/ExecStart/i EnvironmentFile=-/etc/sysconfig/tcmu-runner-params' /usr/lib/systemd/system/tcmu-runner.service
+sed -i  '/tcmu-log-dir=/s/tcmu-log-dir.*/tcmu-log-dir $TCMU_LOGDIR/' /usr/lib/systemd/system/tcmu-runner.service
 
 if [ -c "${HOST_DEV_DIR}/zero" ] && [ -c "${HOST_DEV_DIR}/null" ]; then
     # looks like an alternate "host dev" has been provided


### PR DESCRIPTION
…ster-block service."

This reverts commit e0db6b49e55c55651366d658b35776f848b58e60 as users
reported errors after node/pod reboot as below:
"Failed to get D-Bus connection: Connection refused"

Fixes: https://github.com/gluster/gluster-containers/issues/120
Signed-off-by: Saravanakumar Arumugam <sarumuga@redhat.com>