### PR TITLE
Use env. variable GLUSTER_BLOCK_ENABLED to enable/disable gluster-block-service

### DIFF
--- a/CentOS/Dockerfile
+++ b/CentOS/Dockerfile
@@ -94,8 +94,6 @@ systemctl disable nfs-server.service && \
 systemctl mask getty.target && \
 systemctl enable gluster-fake-disk.service && \
 systemctl enable gluster-setup.service && \
-systemctl enable gluster-block-setup.service && \
-systemctl enable gluster-blockd.service && \
 systemctl enable glusterd.service && \
 systemctl enable gluster-check-diskspace.service
 

--- a/CentOS/README.md
+++ b/CentOS/README.md
@@ -1,5 +1,20 @@
 This dockerfile can be used to build a CentOS Gluster Container.
 
+# Readiness and liveness probes
+
+The container contains a script at `/usr/local/bin/status-probe.sh` that can be
+used to check the status of the services. The script can be called with
+`readiness` or `liveness` as argument.
+
+# Enabling/Disabling gluster-block
+
+Gluster Block is an optional service that can be used to provide
+PersistentVolumes of type=Block. Not everyone needs this functionality, and on
+some distributions the dependencies (in the kernel) might be missing. It is
+possible to disable the Gluster Block service by exporting the
+`GLUSTER_BLOCK_ENABLED` environment variable set to `"0"`. By default the
+environment variable will be set to `"1"` so that the service is enabled.
+
 # Support for fake disks
 
 This container offers several configuration options that make it easier to test

--- a/CentOS/status-probe.sh
+++ b/CentOS/status-probe.sh
@@ -3,6 +3,9 @@
 # Return overall status of the glusterfs container
 #
 
+: ${GLUSTER_BLOCK_ENABLED:=1}
+: ${GLUSTER_BLOCKD_STATUS_PROBE_ENABLE:=1}
+
 require() {
     if ! "$@" ; then
         echo "failed check: $*" >&2
@@ -32,8 +35,8 @@ case "$mode" in
             echo "warning: no mode provided. Assuming liveness probe" >&2
         fi
         require systemctl -q is-active glusterd.service
-        
-        if [[ "$GLUSTER_BLOCKD_STATUS_PROBE_ENABLE" -eq 1 ]]; then
+
+        if [[ "$GLUSTER_BLOCK_ENABLED" -ne 0 ]] && [[ "$GLUSTER_BLOCKD_STATUS_PROBE_ENABLE" -eq 1 ]]; then
             require systemctl -q is-active gluster-blockd.service
         fi
 

--- a/CentOS/update-params.sh
+++ b/CentOS/update-params.sh
@@ -4,17 +4,27 @@
 : ${GB_LOGDIR:=/var/log/glusterfs/gluster-block}
 : ${TCMU_LOGDIR:=/var/log/glusterfs/gluster-block}
 : ${GB_GLFS_LRU_COUNT:=15}
+: ${GLUSTER_BLOCK_ENABLED:=1}
 : ${HOST_DEV_DIR:=/mnt/host-dev}
 
-echo "env variable is set. Update in gluster-blockd.service"
-#FIXME To update in environment file
-sed -i '/GB_GLFS_LRU_COUNT=/s/GB_GLFS_LRU_COUNT=.*/'GB_GLFS_LRU_COUNT="$GB_GLFS_LRU_COUNT"\"'/'  /usr/lib/systemd/system/gluster-blockd.service
-sed -i '/EnvironmentFile/i Environment="GB_LOGDIR='$GB_LOGDIR'"' /usr/lib/systemd/system/gluster-blockd.service
+if [ "$GLUSTER_BLOCK_ENABLED" == 1 ]; then
+        echo "Enabling gluster-block service and updating env. variables"
+        systemctl enable gluster-block-setup.service
+        systemctl enable gluster-blockd.service
 
-sed -i "s#TCMU_LOGDIR=.*#TCMU_LOGDIR='$TCMU_LOGDIR'#g" /etc/sysconfig/tcmu-runner-params
+        #FIXME To update in environment file
+        sed -i '/GB_GLFS_LRU_COUNT=/s/GB_GLFS_LRU_COUNT=.*/'GB_GLFS_LRU_COUNT="$GB_GLFS_LRU_COUNT"\"'/'  /usr/lib/systemd/system/gluster-blockd.service
+        sed -i '/EnvironmentFile/i Environment="GB_LOGDIR='$GB_LOGDIR'"' /usr/lib/systemd/system/gluster-blockd.service
 
-sed -i '/ExecStart/i EnvironmentFile=-/etc/sysconfig/tcmu-runner-params' /usr/lib/systemd/system/tcmu-runner.service
-sed -i  '/tcmu-log-dir=/s/tcmu-log-dir.*/tcmu-log-dir $TCMU_LOGDIR/' /usr/lib/systemd/system/tcmu-runner.service
+        sed -i "s#TCMU_LOGDIR=.*#TCMU_LOGDIR='$TCMU_LOGDIR'#g" /etc/sysconfig/tcmu-runner-params
+
+        sed -i '/ExecStart/i EnvironmentFile=-/etc/sysconfig/tcmu-runner-params' /usr/lib/systemd/system/tcmu-runner.service
+        sed -i  '/tcmu-log-dir=/s/tcmu-log-dir.*/tcmu-log-dir $TCMU_LOGDIR/' /usr/lib/systemd/system/tcmu-runner.service
+else
+        echo "Disabling gluster-block service"
+        systemctl disable gluster-block-setup.service
+        systemctl disable gluster-blockd.service
+fi
 
 if [ -c "${HOST_DEV_DIR}/zero" ] && [ -c "${HOST_DEV_DIR}/null" ]; then
     # looks like an alternate "host dev" has been provided


### PR DESCRIPTION
Enable gluster-block services if `GLUSTER_BLOCK_ENABLED` is `"1"` and disable otherwise.

By default, `GLUSTER_BLOCK_ENABLED` is set as `"1"`.

This change was recently reverted with commit f5409d94. With a small correction to the change, this should now function as expected. The `status-probe.sh` script checks the value for `GLUSTER_BLOCK_ENABLED` and compares it to `1`. However the `update-params.sh` script set the variable by default to `TRUE`. gluster-kubernetes and openshift-ansible both set the variable to `"1"` by default, so should `update-params.sh`.

Updates: #120