### PR TITLE
Prevent LVM commands from using udev

### DIFF
--- a/CentOS/Dockerfile
+++ b/CentOS/Dockerfile
@@ -66,6 +66,7 @@ RUN true \
     && systemctl mask lvm2-lvmetad.socket \
     && sed -i 's/^\sudev_rules\s*=\s*1/udev_rules = 0/' /etc/lvm/lvm.conf \
     && sed -i 's/^\sudev_sync\s*=\s*1/udev_sync= 0/' /etc/lvm/lvm.conf \
+    && sed -i 's/^\sobtain_device_list_from_udev\s*=\s*1/obtain_device_list_from_udev = 0/' /etc/lvm/lvm.conf \
     && true
 
 VOLUME [ "/sys/fs/cgroup" ]

--- a/Fedora/Dockerfile
+++ b/Fedora/Dockerfile
@@ -36,7 +36,7 @@ RUN dnf -y update && \
     sed -i '/Port 22/c\Port 2222' /etc/ssh/sshd_config && \
     sed -i 's/Requires\=rpcbind\.service//g' /usr/lib/systemd/system/glusterd.service && \
     sed -i 's/rpcbind\.service/gluster-setup\.service/g' /usr/lib/systemd/system/glusterd.service && \
-    sed -i.save -e "s#udev_sync = 1#udev_sync = 0#" -e "s#udev_rules = 1#udev_rules = 0#" -e "s#use_lvmetad = 1#use_lvmetad = 0#" /etc/lvm/lvm.conf && \
+    sed -i.save -e "s#udev_sync = 1#udev_sync = 0#" -e "s#udev_rules = 1#udev_rules = 0#" -e "s#use_lvmetad = 1#use_lvmetad = 0#" -e "s#obtain_device_list_from_udev = 1#obtain_device_list_from_udev = 0#" /etc/lvm/lvm.conf && \
     # Back up the default/base configuration. The target directories get
     # overwritten with the directories from the host which are initially
     # empty.


### PR DESCRIPTION
obtain_device_list_from_udev is a configuration option that helps to
disabled udev as used by LVM commands. When udev is not functioning
correctly (like in a container), LVM commands can become *very* slow and
heketi may time out waiting for results.

BUG: https://bugzilla.redhat.com/1676466
See-also: https://sourceware.org/git/?p=lvm2.git;a=commitdiff;h=3ebce8dbd2d9afc031e0737f8feed796ec7a8df9;hp=d19e3727951853093828b072e254e447f7d61c60
Signed-off-by: Niels de Vos <ndevos@redhat.com>