### PR TITLE
centos: if a "host dev" exists bind mount it over /dev

### DIFF
--- a/CentOS/update-params.sh
+++ b/CentOS/update-params.sh
@@ -4,6 +4,7 @@
 : ${GB_LOGDIR:=/var/log/glusterfs/gluster-block}
 : ${TCMU_LOGDIR:=/var/log/glusterfs/gluster-block}
 : ${GB_GLFS_LRU_COUNT:=15}
+: ${HOST_DEV_DIR:=/mnt/host-dev}
 
 echo "env variable is set. Update in gluster-blockd.service"
 #FIXME To update in environment file
@@ -14,6 +15,12 @@ sed -i "s#TCMU_LOGDIR=.*#TCMU_LOGDIR='$TCMU_LOGDIR'#g" /etc/sysconfig/tcmu-runne
 
 sed -i '/ExecStart/i EnvironmentFile=-/etc/sysconfig/tcmu-runner-params' /usr/lib/systemd/system/tcmu-runner.service
 sed -i  '/tcmu-log-dir=/s/tcmu-log-dir.*/tcmu-log-dir $TCMU_LOGDIR/' /usr/lib/systemd/system/tcmu-runner.service
+
+if [ -c "${HOST_DEV_DIR}/zero" ] && [ -c "${HOST_DEV_DIR}/null" ]; then
+    # looks like an alternate "host dev" has been provided
+    # to the container. Use that as our /dev ongoing
+    mount --rbind "${HOST_DEV_DIR}" /dev
+fi
 
 # Hand off to CMD
 exec "$@"


### PR DESCRIPTION
This is a work around for containerization systems that
have a problem with us using the host's /dev directly but we
need a dynamic dev populated for devices, lvs and gluster-block
support.
Eventually it would be nice to move away from needing the
host's /dev but that day is not here yet.

Updates: openshift/openshift-ansible#11229
Signed-off-by: John Mulligan <jmulligan@redhat.com>
Signed-off-by: Niels de Vos <ndevos@redhat.com>