### PR TITLE
gluster-setup: increase cgroup/pids.max to allow many brick processes/threads

### DIFF
--- a/CentOS/update-params.sh
+++ b/CentOS/update-params.sh
@@ -5,6 +5,32 @@
 : ${TCMU_LOGDIR:=/var/log/glusterfs/gluster-block}
 : ${GB_GLFS_LRU_COUNT:=15}
 : ${HOST_DEV_DIR:=/mnt/host-dev}
+: ${CGROUP_PIDS_MAX:=max}
+
+set_cgroup_pids() {
+  local ret=0
+  local pids=$1
+  local cgroup max
+
+  cgroup=$(awk -F: '/:pids:/{print $3}' /proc/self/cgroup)
+
+  max=$(cat /sys/fs/cgroup/pids/"${cgroup}"/pids.max)
+  echo "maximum number of pids configured in cgroups: ${max}"
+
+  echo "${pids}" > /sys/fs/cgroup/pids/"${cgroup}"/pids.max
+  ret=$?
+
+  max=$(cat /sys/fs/cgroup/pids/"${cgroup}"/pids.max)
+  echo "maximum number of pids configured in cgroups (reconfigured): ${max}"
+
+  return ${ret}
+}
+
+# do not change cgroup/pids when CGROUP_PIDS_MAX is set to 0
+if [[ "${CGROUP_PIDS_MAX}" != '0' ]]
+then
+  set_cgroup_pids ${CGROUP_PIDS_MAX}
+fi
 
 echo "env variable is set. Update in gluster-blockd.service"
 #FIXME To update in environment file


### PR DESCRIPTION
docker-1.13.1-94 limits the number of pids (processes+threads) to 4096.
This is too little for an environment where many volumes are served. The
multiplexed brick process has loads of threads, and several of these
processes can be running.

By introducing the CGROUP_PIDS_MAX environment variable, the cgroup for
the pid-limit can be configured for the Gluster container. By default
the value will be set to 'max', as it was before the change in docker.

Bug: https://bugzilla.redhat.com/1698096
See-also: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/Documentation/cgroup-v1/pids.txt
Signed-off-by: Niels de Vos <ndevos@redhat.com>