### PR TITLE
centos: the service for dmeventd daemon is named dm-event.{service,socket}

### DIFF
--- a/CentOS/Dockerfile
+++ b/CentOS/Dockerfile
@@ -87,8 +87,8 @@ RUN true \
 # the service running on the host
 # monitoring of activated LVs can not be done inside the container
 RUN true \
-    && systemctl mask dmevent.service \
-    && systemctl mask dmevent.socket \
+    && systemctl mask dm-event.service \
+    && systemctl mask dm-event.socket \
     && sed -i 's/^\smonitoring\s*=\s*1/monitoring = 0/' /etc/lvm/lvm.conf \
     && true
 


### PR DESCRIPTION
The masked dmevent.{service,socket} have no effect as they are called
dm-event.{service,socket}.

Fixes: 37e02a3 ("centos: prevent dmeventd from running in the container")
Signed-off-by: Niels de Vos <ndevos@redhat.com>