### PR TITLE
centos: disable unintentional starting of dmeventd

### DIFF
--- a/CentOS/Dockerfile
+++ b/CentOS/Dockerfile
@@ -88,7 +88,10 @@ RUN true \
 # monitoring of activated LVs can not be done inside the container
 RUN true \
     && systemctl mask dm-event.service \
+    && systemctl disable dm-event.socket \
     && systemctl mask dm-event.socket \
+    && systemctl disable lvm2-monitor.service \
+    && systemctl mask lvm2-monitor.service \
     && sed -i 's/^\smonitoring\s*=\s*1/monitoring = 0/' /etc/lvm/lvm.conf \
     && true
 


### PR DESCRIPTION
Masking the dm-event.socket is not sufficient as there will remain a
symlink that triggers running the service under
/etc/systemd/system/sockets.target.wants. For this symlink to be
removed, it is required to disable the dm-event.socket before masking
it.

In addition to the socket activation, lvm2-monitor.service triggers
starting of dmeventd as well. There is no intention to monitor LVM
within the container, so this service can be disabled too.

Signed-off-by: Niels de Vos <ndevos@redhat.com>