### PR TITLE
lvm2-monitor.service needs to be enabled as it creates /var/run/lock/

### DIFF
--- a/CentOS/Dockerfile
+++ b/CentOS/Dockerfile
@@ -90,8 +90,6 @@ RUN true \
     && systemctl mask dm-event.service \
     && systemctl disable dm-event.socket \
     && systemctl mask dm-event.socket \
-    && systemctl disable lvm2-monitor.service \
-    && systemctl mask lvm2-monitor.service \
     && sed -i 's/^\smonitoring\s*=\s*1/monitoring = 0/' /etc/lvm/lvm.conf \
     && true
 


### PR DESCRIPTION
directory which is in turn used by tcmu-runner.service

Signed-off-by: Saravanakumar Arumugam <sarumuga@redhat.com>