### PR TITLE
Execute LVM commands on the host instead of in the container

### DIFF
--- a/CentOS/Dockerfile
+++ b/CentOS/Dockerfile
@@ -94,6 +94,7 @@ ADD status-probe.sh /usr/local/bin/status-probe.sh
 ADD tcmu-runner-params /etc/sysconfig/tcmu-runner-params
 ADD gluster-check-diskspace.service  /etc/systemd/system/gluster-check-diskspace.service
 ADD check_diskspace.sh /usr/local/bin/check_diskspace.sh
+ADD exec-on-host.sh /usr/sbin/exec-on-host
 
 RUN chmod 644 /etc/systemd/system/gluster-setup.service && \
 chmod 644 /etc/systemd/system/gluster-check-diskspace.service && \

--- a/CentOS/exec-on-host.sh
+++ b/CentOS/exec-on-host.sh
@@ -1,0 +1,35 @@
+#!/bin/sh
+#
+# Privilege escalation detection
+# - run command on the host, instead of in the container
+# - in case of misconfiguration, run the command in the container anyway
+#
+
+HOST_ROOTFS=${HOST_ROOTFS:-'/rootfs'}
+HOST_ESCAPE="nsenter --root=${HOST_ROOTFS} --mount=${HOST_ROOTFS}/proc/1/ns/mnt --ipc=${HOST_ROOTFS}/proc/1/ns/ipc --net=${HOST_ROOTFS}/proc/1/ns/net --uts=${HOST_ROOTFS}/proc/1/ns/uts"
+
+error() {
+	echo "${@}" > /dev/stderr
+	echo "Running command inside container: ${COMMAND}" > /dev/stderr
+	${COMMAND_FULL}
+	exit $?
+}
+
+COMMAND="${1}"
+COMMAND_FULL="${*}"
+
+# detect /-filesystem of the host
+if [ ! -d "${HOST_ROOTFS}" ]
+then
+	error "The /-filesystem of the host is not at ${HOST_ROOTFS}"
+fi
+
+# check if the HOST_ESCAPE works by running /bin/true on the host
+if ! ${HOST_ESCAPE} /bin/true
+then
+	error "Could not run a command on the host, falling back to run in container."
+fi
+
+echo "Running command on the host: ${COMMAND}" > /dev/stderr
+# shellcheck disable=SC2086, arguments should not be escaped
+exec ${HOST_ESCAPE} ${COMMAND_FULL}

--- a/CentOS/gluster-setup.sh
+++ b/CentOS/gluster-setup.sh
@@ -51,10 +51,10 @@ main () {
   if test "$(ls $GLUSTERFS_CUSTOM_FSTAB)"
   then
         sleep 5
-        pvscan > $GLUSTERFS_LOG_CONT_DIR/pvscan
-        vgscan > $GLUSTERFS_LOG_CONT_DIR/vgscan
-        lvscan > $GLUSTERFS_LOG_CONT_DIR/lvscan
-        vgchange -ay > $GLUSTERFS_LOG_CONT_DIR/vgchange
+        exec-on-host pvscan > $GLUSTERFS_LOG_CONT_DIR/pvscan
+        exec-on-host vgscan > $GLUSTERFS_LOG_CONT_DIR/vgscan
+        exec-on-host lvscan > $GLUSTERFS_LOG_CONT_DIR/lvscan
+        exec-on-host vgchange -ay > $GLUSTERFS_LOG_CONT_DIR/vgchange
 
         mount -a --fstab $GLUSTERFS_CUSTOM_FSTAB &> $GLUSTERFS_LOG_CONT_DIR/mountfstab
         sts=$?
@@ -87,7 +87,7 @@ main () {
         done
         if [ "$(wc -l < $GLUSTERFS_LOG_CONT_DIR/failed_bricks)" -gt 0 ]
         then
-              vgscan --mknodes > $GLUSTERFS_LOG_CONT_DIR/vgscan_mknodes
+              exec-on-host vgscan --mknodes > $GLUSTERFS_LOG_CONT_DIR/vgscan_mknodes
               sleep 10
               mount -a --fstab $GLUSTERFS_LOG_CONT_DIR/failed_bricks
         fi


### PR DESCRIPTION
When Gluster runs in a container, it is recommended to run the LVM
commands on the host, and not inside the container. With the new
'exec-on-host' shell script, the commands are executed through 'nsenter'
which expects the /-filesystem of the host to be bind-mounted (as a
volume) on /rootfs. It is also required that the container runs in the
PID-namespace of the host, so that PID 1 refers to the init process on
the host.

If the /-filesystem is not available under /rootfs in the container, or
running 'true' through the 'exec-on-host' script fails, a fallback is
done to execute the command inside the container anyway.

See-also: https://github.com/heketi/heketi/pull/1650