### PR TITLE
lvm: no need to downgrade lvm2 package anymore

### DIFF
--- a/CentOS/Dockerfile
+++ b/CentOS/Dockerfile
@@ -51,19 +51,6 @@ cp -r /var/lib/glusterd/* /var/lib/glusterd_bkp &&\
 cp -r /var/log/glusterfs/* /var/log/glusterfs_bkp && \
 mkdir -p /var/log/core;
 
-# downgrade lvm2 because of regression reported in https://bugzilla.redhat.com/1676612
-# once the bug is fixed, disable obtain_device_list_from_udev in lvm.conf
-RUN true \
-    && yum -y downgrade device-mapper-libs-1.02.149-10.el7_6.2 \
-                        device-mapper-1.02.149-10.el7_6.2 \
-                        device-mapper-event-libs-1.02.149-10.el7_6.2 \
-                        device-mapper-event-1.02.149-10.el7_6.2 \
-                        device-mapper-persistent-data-0.7.0-0.1.rc6.el7_4.1 \
-                        lvm2-libs-2.02.180-10.el7_6.2 \
-                        lvm2-2.02.180-10.el7_6.2 \
-    && yum -y clean all \
-    && true
-
 # do not run udev (if needed, bind-mount /run/udev instead?)
 RUN true \
     && systemctl mask systemd-udev-trigger.service \


### PR DESCRIPTION
https://bugzilla.redhat.com/1676612 has been fixed, and downgrading to a
previous version is not needed anymore.

Furthermore, the old package is not available any longer on the CentOS
mirrors. This now causes image builds to fail.