### PR TITLE
remove sudo from the containers

### DIFF
--- a/CentOS/Dockerfile
+++ b/CentOS/Dockerfile
@@ -33,14 +33,12 @@ yum --setopt=tsflags=nodocs -y install openssh-clients  && \
 yum --setopt=tsflags=nodocs -y install rsync  && \
 yum --setopt=tsflags=nodocs -y install tar  && \
 yum --setopt=tsflags=nodocs -y install cronie  && \
-yum --setopt=tsflags=nodocs -y install sudo  && \
 yum --setopt=tsflags=nodocs -y install xfsprogs  && \
 yum --setopt=tsflags=nodocs -y install glusterfs  && \
 yum --setopt=tsflags=nodocs -y install glusterfs-server  && \
 yum --setopt=tsflags=nodocs -y install glusterfs-rdma  && \
 yum --setopt=tsflags=nodocs -y install gluster-block  && \
 yum --setopt=tsflags=nodocs -y install glusterfs-geo-replication && yum clean all && \
-sed -i '/Defaults    requiretty/c\#Defaults    requiretty' /etc/sudoers && \
 sed -i '/Port 22/c\Port 2222' /etc/ssh/sshd_config && \
 sed -i 's/Requires\=rpcbind\.service//g' /usr/lib/systemd/system/glusterd.service && \
 sed -i 's/rpcbind\.service/gluster-setup\.service/g' /usr/lib/systemd/system/glusterd.service && \

--- a/Fedora/Dockerfile
+++ b/Fedora/Dockerfile
@@ -31,7 +31,7 @@ COPY fake-disk.sh /usr/libexec/gluster/fake-disk.sh
 
 RUN dnf -y update && \
     sed -i "s/LANG/\#LANG/g" /etc/locale.conf && \
-    dnf -y install systemd-udev glusterfs-server dbus-python nfs-utils attr iputils iproute glusterfs-geo-replication openssh-server openssh-clients cronie tar rsync sos sudo xfsprogs && \
+    dnf -y install systemd-udev glusterfs-server dbus-python nfs-utils attr iputils iproute glusterfs-geo-replication openssh-server openssh-clients cronie tar rsync sos xfsprogs && \
     dnf clean all && \
     sed -i '/Port 22/c\Port 2222' /etc/ssh/sshd_config && \
     sed -i 's/Requires\=rpcbind\.service//g' /usr/lib/systemd/system/glusterd.service && \


### PR DESCRIPTION
We don't need the sudo util when Gluster is containerized.  The
requirements are met by running the container as privileged.

Signed-off-by: Raghavendra Talur <rtalur@redhat.com>