### PR TITLE
mask services that shouldn't run in the container

### DIFF
--- a/CentOS/Dockerfile
+++ b/CentOS/Dockerfile
@@ -82,6 +82,14 @@ RUN true \
     && sed -i 's/^\smonitoring\s*=\s*1/monitoring = 0/' /etc/lvm/lvm.conf \
     && true
 
+# mask services that aren't required in the container and/or might interfere
+RUN true \
+    && systemctl mask getty.target \
+    && systemctl mask systemd-journal-flush.service \
+    && systemctl mask rpcbind.socket \
+    && true
+
+
 VOLUME [ "/sys/fs/cgroup" ]
 ADD gluster-fake-disk.service /etc/systemd/system/gluster-fake-disk.service
 ADD fake-disk.sh /usr/libexec/gluster/fake-disk.sh
@@ -106,7 +114,6 @@ chmod +x /usr/local/bin/update-params.sh && \
 chmod +x /usr/local/bin/status-probe.sh && \
 chmod +x /usr/local/bin/check_diskspace.sh && \
 systemctl disable nfs-server.service && \
-systemctl mask getty.target && \
 systemctl enable gluster-fake-disk.service && \
 systemctl enable gluster-setup.service && \
 systemctl enable gluster-block-setup.service && \

--- a/Fedora/Dockerfile
+++ b/Fedora/Dockerfile
@@ -54,7 +54,6 @@ RUN dnf -y update && \
     ln -s /usr/sbin/gluster-setup.sh /usr/sbin/setup.sh && \
     chmod 644 /etc/systemd/system/gluster-brickmultiplex.service && \
     chmod 500 /usr/sbin/gluster-brickmultiplex.sh && \
-    systemctl mask getty.target && \
     systemctl disable systemd-udev-trigger.service && \
     systemctl disable systemd-udevd.service && \
     systemctl disable nfs-server.service && \
@@ -65,6 +64,13 @@ RUN dnf -y update && \
     systemctl enable gluster-brickmultiplex.service && \
     systemctl enable glusterd.service && \
     mkdir -p /var/log/core;
+
+# mask services that aren't required in the container and/or might interfere
+RUN true \
+    && systemctl mask getty.target \
+    && systemctl mask systemd-journal-flush.service \
+    && systemctl mask rpcbind.socket \
+    && true
 
 EXPOSE 2222 111 245 443 24006 24007 2049 8080 6010 6011 6012 38465 38466 38468 38469 49152 49153 49154 49156 49157 49158 49159 49160 49161 49162
 


### PR DESCRIPTION
Gluster is a privileged systemd container. Therefore disable those
services which are to be run only once and in the host system, not in
the container.

Signed-off-by: Raghavendra Talur <rtalur@redhat.com>