### PR TITLE
FIX: Explicitly set glusterfs version

### DIFF
--- a/CentOS/Dockerfile
+++ b/CentOS/Dockerfile
@@ -15,7 +15,10 @@ LABEL architecture="$ARCH" \
       description="Gluster Image is based on CentOS Image which is a scalable network filesystem. Using common off-the-shelf hardware, you can create large, distributed storage solutions for media streaming, data analysis, and other data- and bandwidth-intensive tasks." \
       io.openshift.tags="gluster,glusterfs,glusterfs-centos"
 
-RUN yum --setopt=tsflags=nodocs -y update && yum install -y centos-release-gluster && yum clean all && \
+ENV GLUSTERFS_RELEASE=41 \
+    GLUSTERFS_PKG=4.1.9
+
+RUN yum --setopt=tsflags=nodocs -y update && yum install -y centos-release-gluster${GLUSTERFS_RELEASE} && yum clean all && \
 (cd /lib/systemd/system/sysinit.target.wants/; for i in *; do [ $i == systemd-tmpfiles-setup.service ] || rm -f $i; done) && \
 rm -f /lib/systemd/system/multi-user.target.wants/* &&\
 rm -f /etc/systemd/system/*.wants/* &&\
@@ -34,11 +37,10 @@ yum --setopt=tsflags=nodocs -y install rsync  && \
 yum --setopt=tsflags=nodocs -y install tar  && \
 yum --setopt=tsflags=nodocs -y install cronie  && \
 yum --setopt=tsflags=nodocs -y install xfsprogs  && \
-yum --setopt=tsflags=nodocs -y install glusterfs  && \
-yum --setopt=tsflags=nodocs -y install glusterfs-server  && \
-yum --setopt=tsflags=nodocs -y install glusterfs-rdma  && \
+yum --setopt=tsflags=nodocs -y install glusterfs-server-${GLUSTERFS_PKG}  && \
+yum --setopt=tsflags=nodocs -y install glusterfs-rdma-${GLUSTERFS_PKG}  && \
 yum --setopt=tsflags=nodocs -y install gluster-block  && \
-yum --setopt=tsflags=nodocs -y install glusterfs-geo-replication && yum clean all && \
+yum --setopt=tsflags=nodocs -y install glusterfs-geo-replication-${GLUSTERFS_PKG} && yum clean all && \
 sed -i '/Port 22/c\Port 2222' /etc/ssh/sshd_config && \
 sed -i 's/Requires\=rpcbind\.service//g' /usr/lib/systemd/system/glusterd.service && \
 sed -i 's/rpcbind\.service/gluster-setup\.service/g' /usr/lib/systemd/system/glusterd.service && \


### PR DESCRIPTION
- Recent CentOS7 include glusterfs 6.0 in base repo that cause
  dependency problem. From now on, package version required.
- Removed redundant `glusterfs` package
  since `glusterfs-server` depends on it anyway.