### PR TITLE
FIX: Interference with journald and logind

### DIFF
--- a/CentOS/Dockerfile
+++ b/CentOS/Dockerfile
@@ -84,6 +84,9 @@ RUN true \
 RUN true \
     && systemctl mask getty.target \
     && systemctl mask systemd-journal-flush.service \
+    && systemctl mask systemd-journald.service \
+    && systemctl mask systemd-journald.socket \
+    && systemctl mask systemd-logind.service \
     && systemctl mask rpcbind.socket \
     && true
 

--- a/Fedora/Dockerfile
+++ b/Fedora/Dockerfile
@@ -69,6 +69,9 @@ RUN dnf -y update && \
 RUN true \
     && systemctl mask getty.target \
     && systemctl mask systemd-journal-flush.service \
+    && systemctl mask systemd-journald.service \
+    && systemctl mask systemd-journald.socket \
+    && systemctl mask systemd-logind.service \
     && systemctl mask rpcbind.socket \
     && true
 


### PR DESCRIPTION
- Fixes: #155
- Containerized `systemd-journald` unconditionally changed `/dev/log`
  SELinux fcontext that cause AVC denies for many services
  (docker, setroubleshootd, etc) upon log writes.