### PR TITLE
Bring CentOS container up to date

### DIFF
--- a/CentOS/Dockerfile
+++ b/CentOS/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos:7
+FROM quay.io/centos/centos:stream9
 
 MAINTAINER Humble Chirammal hchiramm@redhat.com Saravanakumar Arumugam sarumuga@redhat.com
 
@@ -15,7 +15,7 @@ LABEL architecture="$ARCH" \
       description="Gluster Image is based on CentOS Image which is a scalable network filesystem. Using common off-the-shelf hardware, you can create large, distributed storage solutions for media streaming, data analysis, and other data- and bandwidth-intensive tasks." \
       io.openshift.tags="gluster,glusterfs,glusterfs-centos"
 
-RUN yum --setopt=tsflags=nodocs -y update && yum install -y centos-release-gluster && yum clean all && \
+RUN yum --setopt=tsflags=nodocs -y update && yum install -y centos-release-gluster9 && yum clean all && \
 (cd /lib/systemd/system/sysinit.target.wants/; for i in *; do [ $i == systemd-tmpfiles-setup.service ] || rm -f $i; done) && \
 rm -f /lib/systemd/system/multi-user.target.wants/* &&\
 rm -f /etc/systemd/system/*.wants/* &&\

--- a/CentOS/update-params.sh
+++ b/CentOS/update-params.sh
@@ -14,15 +14,15 @@ set_cgroup_pids() {
   local pids=$1
   local cgroup max
 
-  cgroup=$(awk -F: '/:pids:/{print $3}' /proc/self/cgroup)
+  cgroup=$(awk -F: '{print $3}' /proc/self/cgroup)
 
-  max=$(cat /sys/fs/cgroup/pids/"${cgroup}"/pids.max)
+  max=$(cat /sys/fs/cgroup/"${cgroup}"/pids.max)
   echo "maximum number of pids configured in cgroups: ${max}"
 
-  echo "${pids}" > /sys/fs/cgroup/pids/"${cgroup}"/pids.max
+  echo "${pids}" > /sys/fs/cgroup/"${cgroup}"/pids.max
   ret=$?
 
-  max=$(cat /sys/fs/cgroup/pids/"${cgroup}"/pids.max)
+  max=$(cat /sys/fs/cgroup/"${cgroup}"/pids.max)
   echo "maximum number of pids configured in cgroups (reconfigured): ${max}"
 
   return ${ret}


### PR DESCRIPTION
To run this use (taking your built image is tagged with name `gc`):
```sh
docker run -v /etc/glusterfs:/etc/glusterfs:z \
    -v /var/lib/glusterd:/var/lib/glusterd:z \
    -v /var/log/glusterfs:/var/log/glusterfs:z  \
    -v /dev/:/dev --net=host \
    -v /sys/fs/cgroup:/sys/fs/cgroup:rw \
    --privileged --cgroupns=host \
    --rm -it --name=gc gc
```

Regards