### PR TITLE
[build] Publish new release only when the container's files are updated

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - "master"
+    paths:
+      - "CentOS/**"
+      - "Fedora/**"
 
 env:
   REGISTRY: ghcr.io


### PR DESCRIPTION
The current job is triggered even when
we change files like workflows and gitignore.

Signed-off-by: black.dragon74 <nickk.2974@gmail.com>