### PR TITLE
[centos] Clean yum cache once we are done

### DIFF
--- a/CentOS/Dockerfile
+++ b/CentOS/Dockerfile
@@ -15,7 +15,7 @@ LABEL architecture="$ARCH" \
       description="Gluster Image is based on CentOS Image which is a scalable network filesystem. Using common off-the-shelf hardware, you can create large, distributed storage solutions for media streaming, data analysis, and other data- and bandwidth-intensive tasks." \
       io.openshift.tags="gluster,glusterfs,glusterfs-centos"
 
-RUN yum --setopt=tsflags=nodocs -y update && yum install -y centos-release-gluster && yum clean all && \
+RUN yum --setopt=tsflags=nodocs -y update && yum install -y centos-release-gluster && \
 (cd /lib/systemd/system/sysinit.target.wants/; for i in *; do [ $i == systemd-tmpfiles-setup.service ] || rm -f $i; done) && \
 rm -f /lib/systemd/system/multi-user.target.wants/* &&\
 rm -f /etc/systemd/system/*.wants/* &&\


### PR DESCRIPTION
with installing and setting up packages. Cleaning it twice , once in the beginning and once in the end makes no sense as it could all be done in one go.

This patch also saves us a couple of seconds due to the command being run only once.

Signed-off-by: black-dragon74 <nickk.2974@gmail.com>