### PR TITLE
Replace goo.gl shortlink with direct link

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ Number of Peers: 0
 
 That’s it!
 
-Additional Ref# https://goo.gl/3031Mm
+[Additional Ref](https://www.youtube.com/watch?v=4Xf8pmDEZYw)
 
 ##### Capturing coredumps
 


### PR DESCRIPTION
Google's goo.gl shortener [is shutting down next year](https://developers.googleblog.com/en/google-url-shortener-links-will-no-longer-be-available/). I've replaced the link I found with the direct Youtube link.